### PR TITLE
refactor: ブランチ命名規則をConventional Commit形式に変更

### DIFF
--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -72,9 +72,12 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
+    # Only allow conventional commit format (type/description)
+    # Conventional commit types: feat, fix, refactor, docs, chore, style, test, perf, ci, build
+    if [[ ! "$branch" =~ ^(feat|fix|refactor|docs|chore|style|test|perf|ci|build)/ ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: 001-feature-name" >&2
+        echo "Feature branches should be named like: type/description" >&2
+        echo "Valid types: feat, fix, refactor, docs, chore, style, test, perf, ci, build" >&2
         return 1
     fi
 
@@ -83,45 +86,22 @@ check_feature_branch() {
 
 get_feature_dir() { echo "$1/specs/$2"; }
 
-# Find feature directory by numeric prefix instead of exact branch match
-# This allows multiple branches to work on the same spec (e.g., 004-fix-bug, 004-add-feature)
+# Find feature directory for conventional commit format branches
+# Supports format: type/description (e.g., feat/add-dark-mode -> specs/feat-add-dark-mode)
 find_feature_dir_by_prefix() {
     local repo_root="$1"
     local branch_name="$2"
     local specs_dir="$repo_root/specs"
 
-    # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
-    if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then
-        # If branch doesn't have numeric prefix, fall back to exact match
-        echo "$specs_dir/$branch_name"
+    # For conventional commit format (type/description), replace / with - for directory name
+    if [[ "$branch_name" =~ ^(feat|fix|refactor|docs|chore|style|test|perf|ci|build)/ ]]; then
+        local dir_name="${branch_name//\//-}"
+        echo "$specs_dir/$dir_name"
         return
     fi
 
-    local prefix="${BASH_REMATCH[1]}"
-
-    # Search for directories in specs/ that start with this prefix
-    local matches=()
-    if [[ -d "$specs_dir" ]]; then
-        for dir in "$specs_dir"/"$prefix"-*; do
-            if [[ -d "$dir" ]]; then
-                matches+=("$(basename "$dir")")
-            fi
-        done
-    fi
-
-    # Handle results
-    if [[ ${#matches[@]} -eq 0 ]]; then
-        # No match found - return the branch name path (will fail later with clear error)
-        echo "$specs_dir/$branch_name"
-    elif [[ ${#matches[@]} -eq 1 ]]; then
-        # Exactly one match - perfect!
-        echo "$specs_dir/${matches[0]}"
-    else
-        # Multiple matches - this shouldn't happen with proper naming convention
-        echo "ERROR: Multiple spec directories found with prefix '$prefix': ${matches[*]}" >&2
-        echo "Please ensure only one spec directory exists per numeric prefix." >&2
-        echo "$specs_dir/$branch_name"  # Return something to avoid breaking the script
-    fi
+    # Fallback for any other format - use branch name directly
+    echo "$specs_dir/$branch_name"
 }
 
 get_feature_paths() {


### PR DESCRIPTION
## Summary

- 数値プレフィックス形式（`001-feature-name`）を廃止し、Conventional Commit形式（`type/description`）のみを許可するように変更
- 有効なtype: `feat`, `fix`, `refactor`, `docs`, `chore`, `style`, `test`, `perf`, `ci`, `build`
- 既存のフィーチャーブランチにいる場合は新規ブランチ作成をスキップ（worktree対応）
- 既存の`spec.md`がある場合はテンプレート上書きをスキップ

## Changes

- `.specify/scripts/bash/common.sh`: `check_feature_branch`と`find_feature_dir_by_prefix`をConventional Commit形式に対応
- `.specify/scripts/bash/create-new-feature.sh`: `--number`オプションを`--type`オプションに変更、フィーチャーブランチ検出ロジックを追加

## Test plan

- [ ] 新しいフィーチャーブランチ作成時に`type/description`形式で作成される
- [ ] 既存のフィーチャーブランチ（worktree）にいる場合、新規ブランチが作成されない
- [ ] 既存の`spec.md`がある場合、上書きされない

🤖 Generated with [Claude Code](https://claude.com/claude-code)