### PR TITLE
ci: E2Eテストにパスフィルターを追加

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,6 +4,18 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "src/**"
+      - "e2e/**"
+      - "playwright.config.ts"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "next.config.mjs"
+      - "contentlayer.config.ts"
+      - "tailwind.config.ts"
+      - "wrangler.toml"
+      - "migrations/**"
+      - ".github/workflows/e2e.yaml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 概要

E2Eテストのワークフローにパスフィルターを追加し、アプリケーションコードが変更されたときのみ実行されるようにしました。

## 変更内容

以下のファイルが変更されたときのみE2Eテストが実行されます:
- `src/**` - アプリケーションコード
- `e2e/**` - E2Eテスト
- `playwright.config.ts` - Playwright設定
- `package.json`, `pnpm-lock.yaml` - 依存関係
- `next.config.mjs`, `contentlayer.config.ts`, `tailwind.config.ts` - ビルド設定
- `wrangler.toml`, `migrations/**` - Cloudflare/DB設定
- `.github/workflows/e2e.yaml` - ワークフロー自体

CLAUDE.md、README.md、.claude/ などのドキュメント変更ではE2Eテストは実行されません。

## テスト項目

- [x] ワークフローの構文が正しいことを確認