### PR TITLE
chore: Cloudflare WorkersのNodeバージョンを24.12.0に更新

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_flags = [ "nodejs_compat", "global_fetch_strictly_public" ]
 main = ".open-next/worker.js"
 
 [vars]
-NODE_VERSION = "22.12.0"
+NODE_VERSION = "24.12.0"
 
 [assets]
 binding = "ASSETS"


### PR DESCRIPTION
## Summary
- Cloudflare Workersで使用するNodeバージョンを22.12.0から24.12.0に更新

## Test plan
- [ ] デプロイが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)