### PR TITLE
fix: デフォルトテーマをライトテーマに固定

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -58,36 +58,6 @@
   --border-brand: var(--color-purple-600);
 }
 
-/* ===== ダークテーマ（prefers-color-scheme対応） ===== */
-@media (prefers-color-scheme: dark) {
-  :root {
-    /* 背景 */
-    --bg-base: var(--color-navy-950);
-    --bg-surface: var(--color-gray-800);
-    --bg-surface-hover: rgba(134, 200, 243, 0.1);
-    --bg-elevated: var(--color-indigo-900);
-    --bg-muted: var(--color-navy-900);
-
-    /* テキスト */
-    --text-primary: var(--color-white);
-    --text-secondary: var(--color-gray-300);
-    --text-muted: var(--color-gray-400);
-    --text-inverse: var(--color-dark-text);
-    --text-link: var(--color-blue-300);
-    --text-link-hover: var(--color-purple-400);
-
-    /* ブランド/アクセント（変更なし） */
-    --brand-primary: var(--color-purple-600);
-    --brand-primary-dark: var(--color-indigo-900);
-    --brand-primary-light: var(--color-purple-400);
-
-    /* ボーダー */
-    --border-default: var(--color-gray-400);
-    --border-subtle: rgba(170, 170, 170, 0.3);
-    --border-brand: var(--color-purple-600);
-  }
-}
-
 html,
 body {
   @apply bg-bg-base;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,6 @@ const config: Config = {
     "./src/components/**/*.{js,ts,jsx,tsx}",
     "./src/app/**/*.{js,ts,jsx,tsx}",
   ],
-  darkMode: "media",
   plugins: [typography],
   theme: {
     extend: {


### PR DESCRIPTION
## 概要

#81でマージしたデザインシステムでは、`prefers-color-scheme: dark`によりOSの設定に応じてダークテーマに自動切り替わる実装になっていましたが、デフォルトはライトテーマのみとするため、ダークモード対応を削除しました。

## 変更内容

### `src/app/globals.scss`
- `@media (prefers-color-scheme: dark)` のブロックを削除
- ライトテーマのCSS変数のみを残す

### `tailwind.config.ts`
- `darkMode: "media"` の設定を削除

## 動作

- 常にライトテーマで表示されます
- OSのダークモード設定には影響されません

## 将来的な拡張

手動でテーマ切り替えを行う機能を追加する場合は、以下の構造で実装可能です:
1. `[data-theme="dark"]` セレクタでダークテーマのCSS変数を定義
2. ThemeProviderコンポーネントでテーマ状態管理
3. テーマ切り替えUIの実装

## テスト項目

- [x] ライトテーマで正常に表示される
- [x] OSのダークモード設定でもライトテーマのまま
- [x] `pnpm build` が成功する
- [x] `pnpm lint` が成功する