### PR TITLE
fix: Update VRT Baselinesワークフローに依存関係インストールを追加

### DIFF
--- a/.github/workflows/vrt-update-baseline.yaml
+++ b/.github/workflows/vrt-update-baseline.yaml
@@ -30,6 +30,15 @@ jobs:
         with:
           version: 10
 
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.12.0
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Copy snapshots from PR to baselines
         run: |
           PR_NUM=${{ github.event.pull_request.number || inputs.pr_number }}


### PR DESCRIPTION
## 概要

VRTが「update snapshots」チェックボックスなしで常に失敗する問題を修正しました。

## 変更内容

- Update VRT Baselinesワークフローに Node.js セットアップステップを追加
- Update VRT Baselinesワークフローに依存関係インストールステップ (`pnpm install`) を追加

## 関連Issue

なし

## 問題の詳細

Update VRT Baselinesワークフローで依存関係がインストールされていなかったため、wranglerコマンドが見つからず、R2へのベースラインスナップショットのアップロードに失敗していました。

ワークフローログのエラー：
```
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "wrangler" not found
Snapshot home-page-chromium-linux.png not found for PR #94, skipping...
```

その結果、VRTワークフローがR2からベースラインをダウンロードしようとしても、ベースラインが存在しないため常に失敗していました。

## テスト項目

- [ ] Update VRT Baselinesワークフローが正常に実行されること
- [ ] ベースラインスナップショットがR2に正しくアップロードされること
- [ ] VRTワークフローがR2からベースラインを正しくダウンロードできること
- [ ] VRTがベースラインと比較してテストを実行できること

## VRT設定

<!-- UIに意図的な変更がある場合のみチェックしてください -->

- [x] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし（ワークフローファイルの修正のみ）

## 備考

この修正により、今後PRマージ時にUpdate VRT Baselinesワークフローが正常に動作し、ベースラインがR2に保存されるようになります。