### PR TITLE
feat: staging/本番環境のデプロイフローを追加

### DIFF
--- a/.github/workflows/create-production-pr.yaml
+++ b/.github/workflows/create-production-pr.yaml
@@ -1,0 +1,71 @@
+name: Create Production PR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create or update deploy branch
+        run: |
+          # deployブランチが存在するか確認
+          if git ls-remote --heads origin deploy | grep -q deploy; then
+            echo "deploy branch exists"
+            git fetch origin deploy
+            git checkout deploy
+          else
+            echo "Creating new deploy branch from main"
+            git checkout -b deploy
+            git push -u origin deploy
+          fi
+
+      - name: Create PR from main to deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # mainブランチに切り替え
+          git checkout main
+
+          # deployブランチとの差分を確認
+          if git diff --quiet main origin/deploy; then
+            echo "No changes to deploy"
+            exit 0
+          fi
+
+          # PRが既に存在するか確認
+          EXISTING_PR=$(gh pr list --base deploy --head main --state open --json number --jq '.[0].number')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists"
+          else
+            # PRを作成
+            gh pr create \
+              --base deploy \
+              --head main \
+              --title "本番デプロイ: $(date +'%Y-%m-%d %H:%M:%S')" \
+              --body "## 本番デプロイ
+
+このPRをマージすると本番環境へのデプロイが実行されます。
+
+### チェックリスト
+- [ ] staging環境で動作確認済み
+- [ ] すべてのテストがパス
+- [ ] 破壊的変更がないことを確認
+
+---
+*このPRは自動生成されました*" \
+              --label "production"
+          fi

--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -1,0 +1,56 @@
+name: Production Deploy
+
+on:
+  push:
+    branches:
+      - deploy
+    paths:
+      - "src/**"
+      - "public/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "next.config.mjs"
+      - "contentlayer.config.ts"
+      - "tailwind.config.ts"
+      - "wrangler.jsonc"
+      - "tsconfig.json"
+      - "drizzle/**"
+
+env:
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+jobs:
+  production-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.12.0
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build content
+        run: pnpm build:content
+
+      - name: Deploy to production
+        run: |
+          # OpenNext ビルド
+          pnpm exec opennextjs-cloudflare build
+
+          # 本番環境へデプロイ
+          pnpm exec opennextjs-cloudflare upload
+
+          echo "Deployed to production"

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -1,0 +1,60 @@
+name: Staging Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "public/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "next.config.mjs"
+      - "contentlayer.config.ts"
+      - "tailwind.config.ts"
+      - "wrangler.jsonc"
+      - "tsconfig.json"
+      - "drizzle/**"
+
+env:
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  WORKER_NAME: blog
+  WORKERS_SUBDOMAIN: ${{ secrets.WORKERS_SUBDOMAIN }}
+
+jobs:
+  staging-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.12.0
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build content
+        run: pnpm build:content
+
+      - name: Deploy to staging
+        run: |
+          # OpenNext ビルド
+          pnpm exec opennextjs-cloudflare build
+
+          # ステージングバージョンアップロード
+          pnpm exec opennextjs-cloudflare upload --preview-alias staging
+
+          # ステージングURL表示
+          STAGING_URL="https://staging-${{ env.WORKER_NAME }}.${{ env.WORKERS_SUBDOMAIN }}.workers.dev"
+          echo "Deployed to: ${STAGING_URL}"


### PR DESCRIPTION
## 概要

staging環境と本番環境への段階的デプロイフローを構築しました。

## 変更内容

- mainブランチマージ時にstaging環境へ自動デプロイするワークフローを追加
- workflow_dispatchでmainからdeployブランチへのPRを自動作成するワークフローを追加
- deployブランチマージ時に本番環境へ自動デプロイするワークフローを追加

### デプロイフロー

1. **開発**: featureブランチ → mainへPR → マージ
2. **ステージング**: mainマージ後、自動的にstaging環境にデプロイ（https://staging-blog.sh1ma.workers.dev）
3. **本番デプロイ準備**: GitHub Actionsで"Create Production PR"ワークフローを手動実行 → main→deployのPRが作成
4. **本番デプロイ**: PRをマージ → 本番環境に自動デプロイ

## 関連Issue

なし

## テスト項目

- [ ] mainブランチマージ後、staging環境へ正しくデプロイされることを確認
- [ ] "Create Production PR"ワークフローを手動実行して、PRが正しく作成されることを確認
- [ ] 作成されたPRをマージして、本番環境へ正しくデプロイされることを確認

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし（ワークフローのみの変更）

## 備考

- deployブランチは"Create Production PR"ワークフローの初回実行時に自動作成されます
- staging環境のエイリアスは `staging` です