### PR TITLE
docs: gh-prスキルにPRコメント表示機能を追加

### DIFF
--- a/.claude/skills/gh-pr/SKILL.md
+++ b/.claude/skills/gh-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-pr
-description: GitHubのPR（プルリクエスト）を管理する。PR作成、一覧表示、マージ、レビュー、チェックアウト時に使用。「PRを作りたい」「マージして」「レビューして」などのキーワードで発動。
+description: GitHubのPR（プルリクエスト）を管理する。PR作成、一覧表示、マージ、レビュー、チェックアウト、コメント確認時に使用。「PRを作りたい」「マージして」「レビューして」「コメントを確認」などのキーワードで発動。
 ---
 
 # GitHub PR管理
@@ -116,8 +116,45 @@ gh pr list --label "bug"      # ラベルでフィルタ
 gh pr view                    # 現在のブランチのPRを表示
 gh pr view 123                # PR #123を表示
 gh pr view --web              # ブラウザで開く
+gh pr view --comments         # PRのコメントを表示（会話コメントのみ）
 gh pr checkout 123            # PR #123をチェックアウト
 gh pr diff 123                # PR #123の差分を表示
+```
+
+### PRコメント表示
+
+PRのコメントを確認する方法は複数あります。
+
+#### 基本的なコメント表示
+
+```bash
+# 会話コメントを表示（gh pr viewのデフォルト出力に含まれる）
+gh pr view 123 --comments
+
+# JSONフォーマットで詳細情報を取得
+gh pr view 123 --json comments
+
+# すべてのコメント（インラインレビューコメント含む）をAPI経由で取得
+gh api repos/sh1ma/blog/pulls/123/comments
+```
+
+#### コメントの種類
+
+- **会話コメント（Issue comments）**: PR全体に対するコメント。`gh pr view --comments` で表示可能
+- **レビューコメント（Review comments）**: コードの特定行に対するインラインコメント。API経由で取得
+- **レビュー（Reviews）**: 承認/変更要求/コメント。`gh pr view --json reviews` で取得可能
+
+#### 実用例
+
+```bash
+# 現在のブランチのPRのコメントを確認
+gh pr view --comments
+
+# PR #123のすべてのインラインコメントを確認
+gh api repos/sh1ma/blog/pulls/123/comments | jq -r '.[] | "\(.path):\(.line) - \(.user.login): \(.body)"'
+
+# PR #123のレビュー状況を確認
+gh pr view 123 --json reviews | jq -r '.reviews[] | "\(.author.login): \(.state) - \(.body)"'
 ```
 
 ### PRマージ・クローズ
@@ -184,7 +221,8 @@ VRTに関連するPRには `test` ラベルも追加することを推奨しま�
 2. PR作成の場合、変更内容を確認してラベルを決定する
 3. **`.github/pull_request_template.md` のテンプレートを遵守してPRを作成する**
 4. **ラベルを必ず付けてPRを作成する**
-5. 結果を日本語で報告
+5. PRコメント確認の場合、適切なコマンド（`gh pr view --comments`、`gh api`など）を使用する
+6. 結果を日本語で報告
 
 ## 注意事項
 


### PR DESCRIPTION
## 概要

gh-prスキルにPRのコメントを表示・確認する方法を追加しました。これにより、Claude Codeから直接PRのコメントを確認できるようになります。

## 変更内容

- `gh pr view --comments` を使った基本的なコメント表示方法を追加
- コメントの種類（会話コメント、レビューコメント、レビュー）の説明を追加
- API経由でインラインコメントやレビュー状況を確認する実用例を追加
- スキルのdescriptionにコメント確認機能を追記
- 実行手順にPRコメント確認時の指示を追加

## 関連Issue

なし

## テスト項目

- [x] Lintチェック（`pnpm lint`）が通ること
- [x] フォーマットチェック（`pnpm format:check`）が通ること
- [ ] ドキュメントの内容が正確であること

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし（ドキュメントのみの変更）

## 備考

`gh pr view --comments` コマンドについては、GitHub CLIの公式ドキュメントとDeepWikiで調査した内容を基に記述しています。