### PR TITLE
refactor: ESLintの除外設定の冗長なエントリを削除

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -12,23 +12,14 @@ const compat = new FlatCompat({
 export default defineConfig([
   {
     ignores: [
-      ".next",
       ".next/**",
-      ".open-next",
       ".open-next/**",
-      ".wrangler",
       ".wrangler/**",
-      "node_modules",
       "node_modules/**",
-      "out",
       "out/**",
-      "public",
       "public/**",
-      ".contentlayer",
       ".contentlayer/**",
-      "drizzle",
       "drizzle/**",
-      "contentlayer",
       "contentlayer/**",
       "next-env.d.ts",
       "cloudflare-env.d.ts",


### PR DESCRIPTION
## 概要

ESLintの除外設定において、各ディレクトリに対してパターンとグロブパターン（`/**`付き）の両方が指定されていた冗長なエントリを削除しました。

## 変更内容

- `eslint.config.mts` の `ignores` 配列から、`/**` なしのパターンを削除
  - `.next`, `.open-next`, `.wrangler`, `node_modules`, `out`, `public`, `.contentlayer`, `drizzle`, `contentlayer` の各エントリを削除
  - `/**` パターンのみを残すことで、ディレクトリ自体とその配下のすべてのファイルを除外

## 関連Issue

Closes #106

## テスト項目

- [x] `pnpm lint` が正常に実行されることを確認
- [x] `pnpm format:check` が正常に実行されることを確認

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

N/A（設定ファイルの変更のみ）

## 備考

PR #104 のレビューコメント（https://github.com/sh1ma/blog/pull/104#discussion_r2680850932）で指摘された冗長性を解消するためのリファクタリングです。