### PR TITLE
worktree間でClaude設定を共有する仕組みを追加

### DIFF
--- a/.claude/skills/git-worktree/SKILL.md
+++ b/.claude/skills/git-worktree/SKILL.md
@@ -53,8 +53,15 @@ ls worktrees 2>/dev/null || mkdir -p worktrees
 # 2. 新しいブランチとworktreeを同時に作成
 git worktree add worktrees/<branch-name> -b <type>/<short-description>
 
+# 3. Claude設定のシンボリックリンクを作成（絶対パスを使用）
+# メインリポジトリのルートディレクトリを取得
+MAIN_REPO=$(git worktree list --porcelain | grep -m 1 "worktree" | cut -d' ' -f2)
+ln -s "${MAIN_REPO}/.claude/settings.local.json" worktrees/<branch-name>/.claude/settings.local.json
+
 # 例: feat/add-dark-mode ブランチとworktreeを作成
 git worktree add worktrees/add-dark-mode -b feat/add-dark-mode
+MAIN_REPO=$(git worktree list --porcelain | grep -m 1 "worktree" | cut -d' ' -f2)
+ln -s "${MAIN_REPO}/.claude/settings.local.json" worktrees/add-dark-mode/.claude/settings.local.json
 ```
 
 ### Worktree一覧表示
@@ -84,8 +91,10 @@ git worktree add worktrees/<worktree-name> <existing-branch>
 1. ユーザーの作業内容を確認する
 2. 適切なブランチ名を決定する（type/short-description形式）
 3. worktreeを作成する
-4. 作成したworktreeのパスを報告する
-5. 作業完了後、worktreeの削除を案内する
+4. メインリポジトリのパスを取得する（`git worktree list --porcelain`を使用）
+5. Claude設定のシンボリックリンクを絶対パスで作成する（settings.local.jsonをメインリポジトリから参照）
+6. 作成したworktreeのパスを報告する
+7. 作業完了後、worktreeの削除を案内する
 
 ## ディレクトリ構造
 
@@ -105,3 +114,5 @@ blog/
 - 同じブランチで複数のworktreeは作成できない
 - 作業完了後は `git worktree remove` でworktreeを削除すること
 - マージ後はブランチも削除すること
+- `.claude/settings.local.json` はシンボリックリンク（絶対パス）でメインリポジトリと共有される（MCP/コマンド/スキルの許可設定が全worktreeで同期される）
+- シンボリックリンクは必ず絶対パスで作成すること（相対パスでは正しく動作しない場合がある）

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ dev-assets
 # playwright snapshots (darwin/local only)
 *-darwin.png
 *-webkit.png
+
+# claude local settings (shared across worktrees via symlink)
+.claude/settings.local.json


### PR DESCRIPTION
## 概要

worktree間でClaude Codeの設定（MCP/コマンド/スキルの許可設定）を共有できるようにしました。

## 変更内容

- `.gitignore` に `.claude/settings.local.json` を追加（ローカル設定をgit管理から除外）
- `git-worktree` スキルにシンボリックリンク作成処理を追加
  - worktree作成時に自動的にメインリポジトリの `settings.local.json` へのシンボリックリンク（絶対パス）を作成
  - メインリポジトリのパスは `git worktree list --porcelain` で動的に取得
- 実装手順と注意事項をドキュメントに追記

## 関連Issue

なし

## テスト項目

- [x] 現在のworktreeにシンボリックリンクを作成し、メインリポジトリの設定が参照できることを確認
- [x] メインリポジトリで設定を変更し、worktree側でも即座に反映されることを確認
- [x] `git worktree list --porcelain` でメインリポジトリのパスが正しく取得できることを確認
- [x] lint・formatチェックが通ることを確認

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

UIの変更なし

## 備考

今後 `/git-worktree` スキルで新しいworktreeを作成すると、自動的にシンボリックリンクが作成され、すべてのworktreeで許可設定が同期されるようになります。