### PR TITLE
PR作成時にランダム画像をコメントするCIを追加

### DIFF
--- a/.claude/skills/git-worktree/SKILL.md
+++ b/.claude/skills/git-worktree/SKILL.md
@@ -56,11 +56,14 @@ git worktree add worktrees/<branch-name> -b <type>/<short-description>
 # 3. Claude設定のシンボリックリンクを作成（絶対パスを使用）
 # メインリポジトリのルートディレクトリを取得
 MAIN_REPO=$(git worktree list --porcelain | grep -m 1 "worktree" | cut -d' ' -f2)
+# 既存のsettings.local.jsonを削除してからシンボリックリンクを作成
+rm -f worktrees/<branch-name>/.claude/settings.local.json
 ln -s "${MAIN_REPO}/.claude/settings.local.json" worktrees/<branch-name>/.claude/settings.local.json
 
 # 例: feat/add-dark-mode ブランチとworktreeを作成
 git worktree add worktrees/add-dark-mode -b feat/add-dark-mode
 MAIN_REPO=$(git worktree list --porcelain | grep -m 1 "worktree" | cut -d' ' -f2)
+rm -f worktrees/add-dark-mode/.claude/settings.local.json
 ln -s "${MAIN_REPO}/.claude/settings.local.json" worktrees/add-dark-mode/.claude/settings.local.json
 ```
 
@@ -92,7 +95,7 @@ git worktree add worktrees/<worktree-name> <existing-branch>
 2. 適切なブランチ名を決定する（type/short-description形式）
 3. worktreeを作成する
 4. メインリポジトリのパスを取得する（`git worktree list --porcelain`を使用）
-5. Claude設定のシンボリックリンクを絶対パスで作成する（settings.local.jsonをメインリポジトリから参照）
+5. 既存のsettings.local.jsonを削除してから、Claude設定のシンボリックリンクを絶対パスで作成する（settings.local.jsonをメインリポジトリから参照）
 6. 作成したworktreeのパスを報告する
 7. 作業完了後、worktreeの削除を案内する
 
@@ -116,3 +119,4 @@ blog/
 - マージ後はブランチも削除すること
 - `.claude/settings.local.json` はシンボリックリンク（絶対パス）でメインリポジトリと共有される（MCP/コマンド/スキルの許可設定が全worktreeで同期される）
 - シンボリックリンクは必ず絶対パスで作成すること（相対パスでは正しく動作しない場合がある）
+- `git worktree add` 実行時にGitが自動的に `.claude/settings.local.json` をコピーするため、シンボリックリンク作成前に既存ファイルを削除する必要がある

--- a/.github/workflows/random-image-comment.yml
+++ b/.github/workflows/random-image-comment.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   comment-random-image:
     runs-on: ubuntu-latest
@@ -11,13 +15,19 @@ jobs:
       - name: Fetch random image and comment on PR
         env:
           GH_TOKEN: ${{ github.token }}
+          # ランダム画像API用のユーザーID（リポジトリ変数として設定推奨）
+          RANDOM_IMAGE_USER_ID: ${{ vars.RANDOM_IMAGE_USER_ID || 'google-oauth2%7C108347409698494459380' }}
         run: |
           # APIからランダム画像を取得
-          # パイプ文字をURLエンコード（%7C）
-          API_URL="https://kotonoha.sh1ma.dev/api/photos/random?userId=google-oauth2%7C108347409698494459380"
+          # 注: jqコマンドはubuntu-latestランナーに標準装備されています
+          API_URL="https://kotonoha.sh1ma.dev/api/photos/random?userId=${RANDOM_IMAGE_USER_ID}"
 
           echo "Fetching random image from: $API_URL"
-          RESPONSE=$(curl -s "$API_URL")
+          # -f フラグでHTTPエラー（4xx, 5xx）を検出
+          if ! RESPONSE=$(curl -fs "$API_URL"); then
+            echo "::error::Failed to fetch image from API (HTTP error or network failure)"
+            exit 1
+          fi
 
           # レスポンスを確認
           echo "API Response: $RESPONSE"
@@ -63,7 +73,7 @@ jobs:
           EOF
             if [ -n "$TWEET_AUTHOR" ] && [ "$TWEET_AUTHOR" != "null" ]; then
               echo "" >> /tmp/pr-comment.md
-              echo "📸 Photo by [@$TWEET_AUTHOR](https://twitter.com/$TWEET_AUTHOR)" >> /tmp/pr-comment.md
+              echo "📸 Photo by [@$TWEET_AUTHOR](https://x.com/$TWEET_AUTHOR)" >> /tmp/pr-comment.md
               echo "🔗 [元の投稿を見る]($TWEET_URL)" >> /tmp/pr-comment.md
             else
               echo "" >> /tmp/pr-comment.md

--- a/.github/workflows/random-image-comment.yml
+++ b/.github/workflows/random-image-comment.yml
@@ -1,0 +1,77 @@
+name: Random Image Comment
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment-random-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch random image and comment on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # APIからランダム画像を取得
+          API_URL="https://kotonoha.sh1ma.dev/api/photos/random?userId=google-oauth2|108347409698494459380"
+
+          echo "Fetching random image from: $API_URL"
+          RESPONSE=$(curl -s "$API_URL")
+
+          # レスポンスを確認
+          echo "API Response: $RESPONSE"
+
+          # okフィールドをチェック
+          OK=$(echo "$RESPONSE" | jq -r '.ok')
+
+          if [ "$OK" != "true" ]; then
+            ERROR=$(echo "$RESPONSE" | jq -r '.error // "Unknown error"')
+            echo "::error::API error: $ERROR"
+            exit 1
+          fi
+
+          # 画像URLと関連情報を取得
+          IMAGE_URL=$(echo "$RESPONSE" | jq -r '.photo.imageUrl')
+          TWEET_URL=$(echo "$RESPONSE" | jq -r '.photo.tweetUrl // empty')
+          TWEET_AUTHOR=$(echo "$RESPONSE" | jq -r '.photo.tweetAuthorScreenName // empty')
+
+          if [ -z "$IMAGE_URL" ] || [ "$IMAGE_URL" = "null" ]; then
+            echo "::error::画像URLを取得できませんでした"
+            exit 1
+          fi
+
+          echo "Image URL: $IMAGE_URL"
+          echo "Tweet URL: $TWEET_URL"
+          echo "Tweet Author: $TWEET_AUTHOR"
+
+          # PRにコメントを投稿
+          COMMENT="## 🎨 今日のランダム画像
+
+![Random Image]($IMAGE_URL)"
+
+          # ツイート情報があれば追加
+          if [ -n "$TWEET_URL" ] && [ "$TWEET_URL" != "null" ]; then
+            COMMENT="$COMMENT
+
+---"
+            if [ -n "$TWEET_AUTHOR" ] && [ "$TWEET_AUTHOR" != "null" ]; then
+              COMMENT="$COMMENT
+
+📸 Photo by [@$TWEET_AUTHOR](https://twitter.com/$TWEET_AUTHOR)
+🔗 [元の投稿を見る]($TWEET_URL)"
+            else
+              COMMENT="$COMMENT
+
+🔗 [元の投稿を見る]($TWEET_URL)"
+            fi
+          fi
+
+          COMMENT="$COMMENT
+
+---
+
+*PR作成お疲れ様です！*"
+
+          echo "$COMMENT" | gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file -
+
+          echo "✅ ランダム画像のコメントを投稿しました"

--- a/.github/workflows/random-image-comment.yml
+++ b/.github/workflows/random-image-comment.yml
@@ -13,7 +13,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # APIからランダム画像を取得
-          API_URL="https://kotonoha.sh1ma.dev/api/photos/random?userId=google-oauth2|108347409698494459380"
+          # パイプ文字をURLエンコード（%7C）
+          API_URL="https://kotonoha.sh1ma.dev/api/photos/random?userId=google-oauth2%7C108347409698494459380"
 
           echo "Fetching random image from: $API_URL"
           RESPONSE=$(curl -s "$API_URL")
@@ -44,34 +45,41 @@ jobs:
           echo "Tweet URL: $TWEET_URL"
           echo "Tweet Author: $TWEET_AUTHOR"
 
-          # PRにコメントを投稿
-          COMMENT="## 🎨 今日のランダム画像
+          # PRにコメントを投稿（ヒアドキュメントを使用）
+          cat << 'EOF' > /tmp/pr-comment.md
+          ## 🎨 今日のランダム画像
 
-![Random Image]($IMAGE_URL)"
+          ![Random Image](IMAGE_URL_PLACEHOLDER)
+          EOF
+
+          # 画像URLを置換
+          sed -i "s|IMAGE_URL_PLACEHOLDER|$IMAGE_URL|g" /tmp/pr-comment.md
 
           # ツイート情報があれば追加
           if [ -n "$TWEET_URL" ] && [ "$TWEET_URL" != "null" ]; then
-            COMMENT="$COMMENT
+            cat << 'EOF' >> /tmp/pr-comment.md
 
----"
+          ---
+          EOF
             if [ -n "$TWEET_AUTHOR" ] && [ "$TWEET_AUTHOR" != "null" ]; then
-              COMMENT="$COMMENT
-
-📸 Photo by [@$TWEET_AUTHOR](https://twitter.com/$TWEET_AUTHOR)
-🔗 [元の投稿を見る]($TWEET_URL)"
+              echo "" >> /tmp/pr-comment.md
+              echo "📸 Photo by [@$TWEET_AUTHOR](https://twitter.com/$TWEET_AUTHOR)" >> /tmp/pr-comment.md
+              echo "🔗 [元の投稿を見る]($TWEET_URL)" >> /tmp/pr-comment.md
             else
-              COMMENT="$COMMENT
-
-🔗 [元の投稿を見る]($TWEET_URL)"
+              echo "" >> /tmp/pr-comment.md
+              echo "🔗 [元の投稿を見る]($TWEET_URL)" >> /tmp/pr-comment.md
             fi
           fi
 
-          COMMENT="$COMMENT
+          # 最後のメッセージを追加
+          cat << 'EOF' >> /tmp/pr-comment.md
 
----
+          ---
 
-*PR作成お疲れ様です！*"
+          *PR作成お疲れ様です！*
+          EOF
 
-          echo "$COMMENT" | gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file -
+          # PRにコメントを投稿
+          gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file /tmp/pr-comment.md
 
           echo "✅ ランダム画像のコメントを投稿しました"


### PR DESCRIPTION
## 概要

PR作成時に自動的にランダムな画像をコメントするGitHub Actions CIを追加しました。

## 変更内容

- `.github/workflows/random-image-comment.yml` を追加
- PR作成時（`pull_request: opened`）をトリガーとして実行
- `https://kotonoha.sh1ma.dev/api/photos/random` からランダム画像を取得
- 取得した画像URLと投稿情報（作者、ツイートURL）をMarkdown形式でPRにコメント

## 関連Issue

closes #113

## テスト項目

- [ ] このPR自体でCIが動作して画像がコメントされることを確認
- [ ] 画像が正しく表示されることを確認
- [ ] ツイート情報（作者、URL）が正しく表示されることを確認

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

N/A（CI設定のためUIの変更はなし）

## 備考

- APIのレスポンス型に基づいて実装
- エラーハンドリングを含む（APIエラー時は適切にワークフローを失敗させる）
- ツイート情報がない場合にも対応