### PR TITLE
fix: VRTのtweets-pageベースライン欠落を解消（スナップショット一覧を動的導出）

### DIFF
--- a/.github/workflows/vrt-update-baseline.yaml
+++ b/.github/workflows/vrt-update-baseline.yaml
@@ -44,8 +44,10 @@ jobs:
           PR_NUM=${{ github.event.pull_request.number || inputs.pr_number }}
           echo "Copying snapshots from PR #${PR_NUM} to baselines..."
 
-          # R2からPRのスナップショットをダウンロード
-          for snapshot in home-page-chromium-linux.png article-page-chromium-linux.png; do
+          # vrt.spec.ts の toHaveScreenshot() からスナップショット名を導出（追加漏れ防止）
+          SNAPSHOTS=$(grep -oE 'toHaveScreenshot\("[^"]+\.png"' e2e/vrt.spec.ts | sed -E 's/.*toHaveScreenshot\("([^"]+)\.png"/\1/')
+          for name in $SNAPSHOTS; do
+            snapshot="${name}-chromium-linux.png"
             # PRのスナップショットをダウンロード
             pnpm wrangler r2 object get ${{ env.R2_BUCKET }}/snapshots/pr-${PR_NUM}/${snapshot} --file /tmp/${snapshot} --remote || {
               echo "Snapshot ${snapshot} not found for PR #${PR_NUM}, skipping..."

--- a/.github/workflows/vrt.yaml
+++ b/.github/workflows/vrt.yaml
@@ -84,13 +84,15 @@ jobs:
         if: steps.check-update.outputs.update_snapshots != 'true'
         run: |
           mkdir -p e2e/vrt.spec.ts-snapshots
-          # -linuxサフィックス付きファイルを試し、なければサフィックスなしをダウンロード
-          pnpm wrangler r2 object get ${{ env.R2_BUCKET }}/baselines/home-page-chromium-linux.png --file e2e/vrt.spec.ts-snapshots/home-page-chromium-linux.png --remote || \
-            pnpm wrangler r2 object get ${{ env.R2_BUCKET }}/baselines/home-page-chromium.png --file e2e/vrt.spec.ts-snapshots/home-page-chromium-linux.png --remote || \
-            echo "Baseline home-page not found"
-          pnpm wrangler r2 object get ${{ env.R2_BUCKET }}/baselines/article-page-chromium-linux.png --file e2e/vrt.spec.ts-snapshots/article-page-chromium-linux.png --remote || \
-            pnpm wrangler r2 object get ${{ env.R2_BUCKET }}/baselines/article-page-chromium.png --file e2e/vrt.spec.ts-snapshots/article-page-chromium-linux.png --remote || \
-            echo "Baseline article-page not found"
+          # vrt.spec.ts の toHaveScreenshot() からスナップショット名を導出（追加漏れ防止）
+          SNAPSHOTS=$(grep -oE 'toHaveScreenshot\("[^"]+\.png"' e2e/vrt.spec.ts | sed -E 's/.*toHaveScreenshot\("([^"]+)\.png"/\1/')
+          for name in $SNAPSHOTS; do
+            file="${name}-chromium-linux.png"
+            # -linuxサフィックス付きファイルを試し、なければサフィックスなしをダウンロード
+            pnpm wrangler r2 object get ${{ env.R2_BUCKET }}/baselines/${file} --file e2e/vrt.spec.ts-snapshots/${file} --remote || \
+              pnpm wrangler r2 object get ${{ env.R2_BUCKET }}/baselines/${name}-chromium.png --file e2e/vrt.spec.ts-snapshots/${file} --remote || \
+              echo "Baseline ${name} not found"
+          done
 
       - name: Run VRT tests
         id: vrt


### PR DESCRIPTION
## 概要

`/tweets` ページのVRTが毎回「snapshot doesn't exist」で失敗していた問題を修正する。原因はVRTワークフローがスナップショット名をハードコードしており、後から追加された `tweets-page` のベースラインがR2に登録されないことだった。

## 変更内容

- `vrt.yaml` のベースラインダウンロード処理を、`e2e/vrt.spec.ts` の `toHaveScreenshot()` 呼び出しからスナップショット名を動的導出する方式に変更
- `vrt-update-baseline.yaml` のベースライン昇格処理も同様に動的導出方式へ変更
- これによりVRTテスト追加時の更新漏れを構造的に防止

### 根本原因の詳細

- `vrt.yaml`: ダウンロード対象が `home-page` / `article-page` のみハードコードされており `tweets-page` のベースラインを取得していなかった
- `vrt-update-baseline.yaml`: マージ時のベースライン昇格対象も同2ページのみで、`tweets-page` のベースラインがR2 `baselines/` に永久に登録されなかった
- 結果 `baselines/tweets-page-chromium-linux.png` がR2に存在せず、比較対象が無いためテストが失敗していた
- なお表示の決定性は問題なし（seedの相対時刻は整数時間に丸められ「N時間前」で安定。既存のhome-page VRTが同seedで成立済み）

## 関連Issue

なし

## テスト項目

- [ ] このPRのVRTがスナップショット更新モードで実行され、`tweets-page` を含む全スナップショットがR2にアップロードされること
- [ ] マージ後、`vrt-update-baseline` により `baselines/tweets-page-chromium-linux.png` がR2に登録されること
- [ ] 以降のPR（Renovate含む、要rebase）でtweets-pageのVRTが比較成功すること

## VRT設定

<!-- UIに意図的な変更がある場合のみチェックしてください -->

- [x] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし

## 備考

- このPRをマージすると、更新モードで生成された `tweets-page` スナップショットがベースラインとして初期登録される（ブートストラップ）。
- 既存PRブランチ（Renovate群など）は古い `vrt.yaml` を持つため、本PRマージ後にmainへrebaseして初めて新方式のダウンロードが効く点に注意。