### PR TITLE
fix: OGP/feed の SITE_URL を環境ごとに注入

### DIFF
--- a/.github/workflows/preview-deploy.yaml
+++ b/.github/workflows/preview-deploy.yaml
@@ -84,19 +84,25 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Compute preview URL
+        id: preview
+        run: |
+          PR_NUM=${{ github.event.pull_request.number }}
+          ALIAS="pr-${PR_NUM}"
+          PREVIEW_URL="https://${ALIAS}-${{ env.WORKER_NAME }}.${{ env.WORKERS_SUBDOMAIN }}.workers.dev"
+          echo "alias=${ALIAS}" >> $GITHUB_OUTPUT
+          echo "preview_url=${PREVIEW_URL}" >> $GITHUB_OUTPUT
+
       - name: Build
+        env:
+          SITE_URL: ${{ steps.preview.outputs.preview_url }}
         run: pnpm build
 
       - name: Deploy preview
         id: deploy
         run: |
-          PR_NUM=${{ github.event.pull_request.number }}
-          ALIAS="pr-${PR_NUM}"
-
-          pnpm exec wrangler versions upload --preview-alias ${ALIAS}
-
-          PREVIEW_URL="https://${ALIAS}-${{ env.WORKER_NAME }}.${{ env.WORKERS_SUBDOMAIN }}.workers.dev"
-          echo "preview_url=${PREVIEW_URL}" >> $GITHUB_OUTPUT
+          pnpm exec wrangler versions upload --preview-alias ${{ steps.preview.outputs.alias }}
+          echo "preview_url=${{ steps.preview.outputs.preview_url }}" >> $GITHUB_OUTPUT
 
       - name: Update comment on success
         if: success()

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -47,6 +47,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
+        env:
+          SITE_URL: https://staging-${{ env.WORKER_NAME }}.${{ env.WORKERS_SUBDOMAIN }}.workers.dev
         run: pnpm build
 
       - name: Deploy to staging

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ tmp
 .open-next
 
 # git worktrees
-worktrees
+worktrees/
 
 # assets for development
 dev-assets

--- a/scripts/build-feed.ts
+++ b/scripts/build-feed.ts
@@ -4,7 +4,7 @@ import dayjs from "dayjs"
 import { Feed } from "feed"
 import { allArticles } from "../.contentlayer/generated/index.mjs"
 
-const SITE_URL = "https://blog.sh1ma.dev"
+const SITE_URL = process.env.SITE_URL ?? "https://blog.sh1ma.dev"
 const OUT_DIR = path.resolve("./dist")
 const OUT_FILE = path.join(OUT_DIR, "feed.xml")
 

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -33,10 +33,10 @@ const textColors = {
 
 // テキスト安全領域 (この矩形の内側には図形を配置しない)
 // タイトル最大 3 行 + 日付 / サイト名行が入るサイズ
-const TEXT_ZONE = { x: 120, y: 175, w: WIDTH - 240, h: 280 }
+const TEXT_ZONE = { x: 130, y: 175, w: WIDTH - 260, h: 280 }
 
 // キャンバス外への overflow 許容量
-const OVERFLOW_MARGIN = 90
+const OVERFLOW_MARGIN = 120
 
 const loadFonts = async () => {
   return Promise.all(
@@ -80,7 +80,19 @@ const SHAPE_TYPES: readonly ShapeType[] = [
 
 type BBox = { x: number; y: number; w: number; h: number }
 
-// bbox の中に 1 つの図形を返す
+// 図形をランダム回転でラップする (transform="rotate(angle cx cy)")
+const withRotation = (elem: unknown, cx: number, cy: number, angle: number) => {
+  if (Math.abs(angle) < 0.5) return elem
+  return {
+    type: "g",
+    props: {
+      transform: `rotate(${angle.toFixed(1)} ${cx.toFixed(1)} ${cy.toFixed(1)})`,
+      children: elem,
+    },
+  }
+}
+
+// bbox の中に 1 つの図形を返す (ランダム回転付き)
 const buildShape = (
   type: ShapeType,
   bbox: BBox,
@@ -89,97 +101,157 @@ const buildShape = (
 ) => {
   const { x, y, w, h } = bbox
   const rand = (min: number, max: number) => min + rng() * (max - min)
-
-  if (type === "triangle") {
-    // bbox 底辺の 2 点 + 上辺のどこか 1 点 (二等辺気味〜スケール気味)
-    const p1 = [x + rand(0, w * 0.25), y + h]
-    const p2 = [x + w - rand(0, w * 0.25), y + h]
-    const p3 = [x + rand(0.3, 0.7) * w, y + rand(0, w * 0.15)]
-    return {
-      type: "polygon",
-      props: {
-        points: [p1, p2, p3].map(([px, py]) => `${px},${py}`).join(" "),
-        fill: color,
-      },
-    }
-  }
-
-  if (type === "ellipse") {
-    return {
-      type: "ellipse",
-      props: {
-        cx: x + w / 2,
-        cy: y + h / 2,
-        rx: (w / 2) * rand(0.75, 1),
-        ry: (h / 2) * rand(0.75, 1),
-        fill: color,
-      },
-    }
-  }
-
-  if (type === "rectangle") {
-    // 一部を角丸にしてバリエーションを出す
-    const rectW = w * rand(0.6, 0.95)
-    const rectH = h * rand(0.6, 0.95)
-    return {
-      type: "rect",
-      props: {
-        x: x + (w - rectW) / 2,
-        y: y + (h - rectH) / 2,
-        width: rectW,
-        height: rectH,
-        rx: rng() < 0.4 ? rand(10, 24) : 0,
-        fill: color,
-      },
-    }
-  }
-
-  // geometric: 円環 / 十字 / 菱形 / X のいずれか
-  const variant = Math.floor(rng() * 4)
   const cx = x + w / 2
   const cy = y + h / 2
-  const r = Math.min(w, h) / 2
+  const rotation = rand(-180, 180)
 
-  if (variant === 0) {
-    // ring (輪郭のみの円)
-    return {
-      type: "circle",
-      props: {
-        cx,
-        cy,
-        r: r * 0.85,
-        fill: "transparent",
-        stroke: color,
-        strokeWidth: rand(12, 18),
-      },
+  const buildElement = () => {
+    if (type === "triangle") {
+      const p1 = [x + rand(0, w * 0.25), y + h]
+      const p2 = [x + w - rand(0, w * 0.25), y + h]
+      const p3 = [x + rand(0.3, 0.7) * w, y + rand(0, w * 0.15)]
+      return {
+        type: "polygon",
+        props: {
+          points: [p1, p2, p3].map(([px, py]) => `${px},${py}`).join(" "),
+          fill: color,
+        },
+      }
     }
-  }
 
-  if (variant === 1) {
-    // plus (+)
-    const armLong = r * 1.7
-    const armShort = r * 0.55
+    if (type === "ellipse") {
+      return {
+        type: "ellipse",
+        props: {
+          cx,
+          cy,
+          rx: (w / 2) * rand(0.75, 1),
+          ry: (h / 2) * rand(0.75, 1),
+          fill: color,
+        },
+      }
+    }
+
+    if (type === "rectangle") {
+      const rectW = w * rand(0.55, 0.95)
+      const rectH = h * rand(0.55, 0.95)
+      return {
+        type: "rect",
+        props: {
+          x: x + (w - rectW) / 2,
+          y: y + (h - rectH) / 2,
+          width: rectW,
+          height: rectH,
+          rx: rng() < 0.4 ? rand(10, 24) : 0,
+          fill: color,
+        },
+      }
+    }
+
+    // geometric: 円環 / 十字 / 菱形 / X のいずれか
+    const variant = Math.floor(rng() * 4)
+    const r = Math.min(w, h) / 2
+
+    if (variant === 0) {
+      // ring (輪郭のみの円)
+      return {
+        type: "circle",
+        props: {
+          cx,
+          cy,
+          r: r * 0.85,
+          fill: "transparent",
+          stroke: color,
+          strokeWidth: rand(12, 18),
+        },
+      }
+    }
+
+    if (variant === 1) {
+      // plus (+)
+      const armLong = r * 1.7
+      const armShort = r * 0.55
+      return {
+        type: "g",
+        props: {
+          children: [
+            {
+              type: "rect",
+              props: {
+                x: cx - armLong / 2,
+                y: cy - armShort / 2,
+                width: armLong,
+                height: armShort,
+                fill: color,
+              },
+            },
+            {
+              type: "rect",
+              props: {
+                x: cx - armShort / 2,
+                y: cy - armLong / 2,
+                width: armShort,
+                height: armLong,
+                fill: color,
+              },
+            },
+          ],
+        },
+      }
+    }
+
+    if (variant === 2) {
+      // diamond (菱形)
+      const rx = r * 0.9
+      const ry = r * 0.75
+      const pts = [
+        [cx, cy - ry],
+        [cx + rx, cy],
+        [cx, cy + ry],
+        [cx - rx, cy],
+      ]
+      return {
+        type: "polygon",
+        props: {
+          points: pts.map(([px, py]) => `${px},${py}`).join(" "),
+          fill: color,
+        },
+      }
+    }
+
+    // variant 3: X 型
+    const thick = r * 0.35
+    const long = r * 1.6
+    const s = Math.SQRT1_2
+    const arm = long / 2
+    const t = thick / 2
+    const bar1 = [
+      [cx - arm * s - t * s, cy - arm * s + t * s],
+      [cx - arm * s + t * s, cy - arm * s - t * s],
+      [cx + arm * s + t * s, cy + arm * s - t * s],
+      [cx + arm * s - t * s, cy + arm * s + t * s],
+    ]
+    const bar2 = [
+      [cx + arm * s - t * s, cy - arm * s - t * s],
+      [cx + arm * s + t * s, cy - arm * s + t * s],
+      [cx - arm * s + t * s, cy + arm * s + t * s],
+      [cx - arm * s - t * s, cy + arm * s - t * s],
+    ]
     return {
       type: "g",
       props: {
         children: [
           {
-            type: "rect",
+            type: "polygon",
             props: {
-              x: cx - armLong / 2,
-              y: cy - armShort / 2,
-              width: armLong,
-              height: armShort,
+              points: bar1.map(([px, py]) => `${px},${py}`).join(" "),
               fill: color,
             },
           },
           {
-            type: "rect",
+            type: "polygon",
             props: {
-              x: cx - armShort / 2,
-              y: cy - armLong / 2,
-              width: armShort,
-              height: armLong,
+              points: bar2.map(([px, py]) => `${px},${py}`).join(" "),
               fill: color,
             },
           },
@@ -188,134 +260,7 @@ const buildShape = (
     }
   }
 
-  if (variant === 2) {
-    // diamond (回転四角)
-    const rx = r * 0.9
-    const ry = r * 0.75
-    const pts = [
-      [cx, cy - ry],
-      [cx + rx, cy],
-      [cx, cy + ry],
-      [cx - rx, cy],
-    ]
-    return {
-      type: "polygon",
-      props: {
-        points: pts.map(([px, py]) => `${px},${py}`).join(" "),
-        fill: color,
-      },
-    }
-  }
-
-  // variant 3: X 型 (2 本の細長い長方形を回転させたポリゴン)
-  const thick = r * 0.35
-  const long = r * 1.6
-  // 45 度回転で 2 本のバーを描く。ここではポリゴンで表現
-  const s = Math.SQRT1_2
-  const arm = long / 2
-  const t = thick / 2
-  // バー1: 左上 → 右下方向
-  const bar1 = [
-    [cx - arm * s - t * s, cy - arm * s + t * s],
-    [cx - arm * s + t * s, cy - arm * s - t * s],
-    [cx + arm * s + t * s, cy + arm * s - t * s],
-    [cx + arm * s - t * s, cy + arm * s + t * s],
-  ]
-  // バー2: 右上 → 左下方向
-  const bar2 = [
-    [cx + arm * s - t * s, cy - arm * s - t * s],
-    [cx + arm * s + t * s, cy - arm * s + t * s],
-    [cx - arm * s + t * s, cy + arm * s + t * s],
-    [cx - arm * s - t * s, cy + arm * s - t * s],
-  ]
-  return {
-    type: "g",
-    props: {
-      children: [
-        {
-          type: "polygon",
-          props: {
-            points: bar1.map(([px, py]) => `${px},${py}`).join(" "),
-            fill: color,
-          },
-        },
-        {
-          type: "polygon",
-          props: {
-            points: bar2.map(([px, py]) => `${px},${py}`).join(" "),
-            fill: color,
-          },
-        },
-      ],
-    },
-  }
-}
-
-// TEXT_ZONE の外周上の点 (パラメータ t で 1 周する) と、外向き法線
-type PerimeterPoint = {
-  x: number
-  y: number
-  nx: number
-  ny: number
-  edge: "top" | "right" | "bottom" | "left"
-  // corner 付近では法線を斜め方向にブレンドしたい
-  cornerBias: number // 0=辺の中央, 1=完全な角
-}
-
-const perimeterAt = (t: number): PerimeterPoint => {
-  const z = TEXT_ZONE
-  const p = 2 * (z.w + z.h)
-  let s = ((t % p) + p) % p
-  const cornerBand = 60 // 角から60px以内は cornerBias が上がる
-
-  const bias = (distToCorner: number) =>
-    Math.max(0, 1 - distToCorner / cornerBand)
-
-  if (s < z.w) {
-    const distCorner = Math.min(s, z.w - s)
-    return {
-      x: z.x + s,
-      y: z.y,
-      nx: 0,
-      ny: -1,
-      edge: "top",
-      cornerBias: bias(distCorner),
-    }
-  }
-  s -= z.w
-  if (s < z.h) {
-    const distCorner = Math.min(s, z.h - s)
-    return {
-      x: z.x + z.w,
-      y: z.y + s,
-      nx: 1,
-      ny: 0,
-      edge: "right",
-      cornerBias: bias(distCorner),
-    }
-  }
-  s -= z.h
-  if (s < z.w) {
-    const distCorner = Math.min(s, z.w - s)
-    return {
-      x: z.x + z.w - s,
-      y: z.y + z.h,
-      nx: 0,
-      ny: 1,
-      edge: "bottom",
-      cornerBias: bias(distCorner),
-    }
-  }
-  s -= z.w
-  const distCorner = Math.min(s, z.h - s)
-  return {
-    x: z.x,
-    y: z.y + z.h - s,
-    nx: -1,
-    ny: 0,
-    edge: "left",
-    cornerBias: bias(distCorner),
-  }
+  return withRotation(buildElement(), cx, cy, rotation)
 }
 
 // bbox と TEXT_ZONE の重なり判定
@@ -328,68 +273,150 @@ const intersectsTextZone = (bbox: BBox) => {
   )
 }
 
-// 「デザインされたランダム感」: 外周を N 分割し、各セグメントに 1 個ずつ
-// 図形を置く。位置は少しジッター、サイズは 3 段階から傾斜サンプリング
+// 外周を 4 バンドに分け、それぞれに図形を密に配置する。
+// - 上下 (横に長い): 多くの図形
+// - 左右 (縦に長い、幅は狭い): 少なめだが必ず存在
+// - サイズと位置はジッター、キャンバス端に到達 (overflow) しやすい
+type Band = "top" | "right" | "bottom" | "left"
+
+const bandExtents = (band: Band) => {
+  const O = OVERFLOW_MARGIN
+  if (band === "top") {
+    return { xMin: -O, xMax: WIDTH + O, yMin: -O, yMax: TEXT_ZONE.y }
+  }
+  if (band === "bottom") {
+    return {
+      xMin: -O,
+      xMax: WIDTH + O,
+      yMin: TEXT_ZONE.y + TEXT_ZONE.h,
+      yMax: HEIGHT + O,
+    }
+  }
+  if (band === "left") {
+    return {
+      xMin: -O,
+      xMax: TEXT_ZONE.x,
+      yMin: TEXT_ZONE.y,
+      yMax: TEXT_ZONE.y + TEXT_ZONE.h,
+    }
+  }
+  return {
+    xMin: TEXT_ZONE.x + TEXT_ZONE.w,
+    xMax: WIDTH + O,
+    yMin: TEXT_ZONE.y,
+    yMax: TEXT_ZONE.y + TEXT_ZONE.h,
+  }
+}
+
+// 与えられた band 内にランダムに 1 個の bbox を返す (テキスト領域と非交差)
+const sampleInBand = (
+  band: Band,
+  size: number,
+  rand: (a: number, b: number) => number,
+): BBox | null => {
+  const ext = bandExtents(band)
+  const half = size / 2
+  const availW = ext.xMax - ext.xMin
+  const availH = ext.yMax - ext.yMin
+  if (availW < 20 || availH < 20) return null
+  // half がバンド寸法より大きいときは "半分以上はみ出す" 状態を許容するので、
+  // 中心座標を band 範囲でクランプ
+  const cxMin = ext.xMin + Math.min(half, availW / 2 - 10)
+  const cxMax = ext.xMax - Math.min(half, availW / 2 - 10)
+  const cyMin = ext.yMin + Math.min(half, availH / 2 - 10)
+  const cyMax = ext.yMax - Math.min(half, availH / 2 - 10)
+  const cx = rand(cxMin, cxMax)
+  const cy = rand(cyMin, cyMax)
+  const bbox: BBox = { x: cx - half, y: cy - half, w: size, h: size }
+  if (intersectsTextZone(bbox)) return null
+  return bbox
+}
+
+const pickSize = (
+  rng: () => number,
+  rand: (a: number, b: number) => number,
+) => {
+  const r = rng()
+  if (r < 0.2) return rand(50, 90) // 小 (点描)
+  if (r < 0.7) return rand(90, 170) // 中
+  if (r < 0.92) return rand(170, 240) // 大
+  return rand(240, 320) // 特大アクセント
+}
+
 const generateShapeBBoxes = (rng: () => number): BBox[] => {
   const rand = (min: number, max: number) => min + rng() * (max - min)
-  const p = 2 * (TEXT_ZONE.w + TEXT_ZONE.h)
   const bboxes: BBox[] = []
-  // 個数: 16〜22
-  const n = 16 + Math.floor(rng() * 7)
 
-  for (let i = 0; i < n; i++) {
-    // 均等 t + ジッター (隣接セグメントの中央までのみブレる)
-    const baseT = ((i + 0.5) * p) / n
-    const jitterT = (rng() - 0.5) * (p / n) * 0.85
-    const t = baseT + jitterT
-    const pt = perimeterAt(t)
-
-    // サイズ分布: 小さめ 20% / 中 55% / 大 25%
-    const r = rng()
-    let size: number
-    if (r < 0.2) size = rand(50, 90)
-    else if (r < 0.75) size = rand(90, 160)
-    else size = rand(160, 230)
-    const half = size / 2
-
-    // 外向きに押し出す距離。half より少し多めで、少しジッター
-    const push = half + rand(0, 55)
-
-    // 角付近では法線を斜めに寄せる (辺方向の tangent 成分を混ぜる)
-    // top/bottom 辺の tangent は ±x, left/right の tangent は ±y
-    let nx = pt.nx
-    let ny = pt.ny
-    if (pt.cornerBias > 0) {
-      // どちらのコーナー寄りか (辺の前半 or 後半)
-      // ここでは単純に「角の近く」の場合、tangent 成分を追加して斜めにする
-      const tangentSign = rng() < 0.5 ? 1 : -1
-      const tx = pt.edge === "top" || pt.edge === "bottom" ? tangentSign : 0
-      const ty = pt.edge === "left" || pt.edge === "right" ? tangentSign : 0
-      const w = pt.cornerBias * 0.9
-      nx = nx * (1 - w) + tx * w
-      ny = ny * (1 - w) + ty * w
-      const mag = Math.hypot(nx, ny) || 1
-      nx /= mag
-      ny /= mag
-    }
-
-    const cx = pt.x + nx * push
-    const cy = pt.y + ny * push
-
-    const bbox = { x: cx - half, y: cy - half, w: size, h: size }
-    // 念のためテキスト領域と重なる場合はスキップ
-    if (intersectsTextZone(bbox)) continue
-    // キャンバス外側にほとんど出過ぎているものもスキップ
-    if (
-      bbox.x + bbox.w < -OVERFLOW_MARGIN ||
-      bbox.x > WIDTH + OVERFLOW_MARGIN ||
-      bbox.y + bbox.h < -OVERFLOW_MARGIN ||
-      bbox.y > HEIGHT + OVERFLOW_MARGIN
-    ) {
-      continue
-    }
-    bboxes.push(bbox)
+  // 各辺に必ず十分な数を割り当てる
+  // 上下: 12〜16 個ずつ、左右: 5〜8 個ずつ → 合計 34〜48 個
+  const counts: Record<Band, number> = {
+    top: 12 + Math.floor(rng() * 5),
+    bottom: 12 + Math.floor(rng() * 5),
+    left: 5 + Math.floor(rng() * 4),
+    right: 5 + Math.floor(rng() * 4),
   }
+
+  const bands: Band[] = ["top", "bottom", "left", "right"]
+  for (const band of bands) {
+    for (let i = 0; i < counts[band]; i++) {
+      // 十分な回数試行 (テキスト非交差の bbox を得るため)
+      for (let attempt = 0; attempt < 6; attempt++) {
+        const size = pickSize(rng, rand)
+        const bbox = sampleInBand(band, size, rand)
+        if (bbox) {
+          bboxes.push(bbox)
+          break
+        }
+      }
+    }
+  }
+
+  // 4 辺すべてに canvas 端に接する図形が最低 1 個は欲しい
+  // (中心を端 or 端の少し外に置いて、bbox が端をまたぐようにする)
+  const ensureEdgeContact: {
+    edge: "top" | "bottom" | "left" | "right"
+    band: Band
+  }[] = [
+    { edge: "top", band: "top" },
+    { edge: "bottom", band: "bottom" },
+    { edge: "left", band: "left" },
+    { edge: "right", band: "right" },
+  ]
+  for (const { edge, band } of ensureEdgeContact) {
+    // 既に接している bbox があるかチェック
+    const hasContact = bboxes.some((b) => {
+      if (edge === "top") return b.y <= 0
+      if (edge === "bottom") return b.y + b.h >= HEIGHT
+      if (edge === "left") return b.x <= 0
+      return b.x + b.w >= WIDTH
+    })
+    if (hasContact) continue
+    // 端を跨ぐ図形を無理やり追加
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const size = rand(140, 220)
+      const half = size / 2
+      let cx: number, cy: number
+      if (edge === "top" || edge === "bottom") {
+        cx = rand(80, WIDTH - 80)
+        cy =
+          edge === "top"
+            ? rand(-half + 15, -20)
+            : rand(HEIGHT + 20, HEIGHT + half - 15)
+      } else {
+        cy = rand(TEXT_ZONE.y + 20, TEXT_ZONE.y + TEXT_ZONE.h - 20)
+        cx =
+          edge === "left"
+            ? rand(-half + 15, -20)
+            : rand(WIDTH + 20, WIDTH + half - 15)
+      }
+      const bbox: BBox = { x: cx - half, y: cy - half, w: size, h: size }
+      if (intersectsTextZone(bbox)) continue
+      bboxes.push(bbox)
+      break
+    }
+    void band
+  }
+
   return bboxes
 }
 

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -24,17 +24,12 @@ const FONT_URLS = [
   },
 ]
 
-const rootBorderColor =
-  "linear-gradient(to left bottom , #6365f7 20%, #f8dbe9 , #afdee8)"
+// 元のグラデーション枠と揃えた4色。角ごとにシャッフルされる
+const CORNER_PALETTE = ["#6365f7", "#f8dbe9", "#afdee8", "#b8bdf2"]
 const textColors = {
   title: "#303036",
   meta: "#6365f7",
   time: "#b8bdf2",
-}
-const borderSize = 72
-const titleContainerSize = {
-  width: WIDTH - borderSize,
-  height: HEIGHT - borderSize,
 }
 
 const loadFonts = async () => {
@@ -55,81 +50,185 @@ const loadFonts = async () => {
   )
 }
 
-const buildNode = (title: string, publishedAt: string) => ({
-  type: "div",
-  props: {
-    style: {
-      width: "100%",
-      height: "100%",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      backgroundImage: rootBorderColor,
-      color: textColors.title,
-      fontFamily: FONT_FAMILY,
-    },
-    children: {
-      type: "div",
-      props: {
-        style: {
-          fontSize: 60,
-          fontWeight: 600,
-          backgroundColor: "white",
-          width: titleContainerSize.width,
-          height: titleContainerSize.height,
-          borderRadius: 8,
-          padding: "24px 48px",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-between",
-        },
-        children: [
-          {
-            type: "div",
-            props: { style: { display: "flex" }, children: title },
-          },
-          {
-            type: "div",
-            props: {
-              style: {
-                display: "flex",
-                gap: 48,
-                marginBottom: 16,
-                justifyContent: "space-between",
-                alignItems: "flex-end",
-              },
-              children: [
-                {
-                  type: "div",
-                  props: {
-                    style: {
-                      display: "flex",
-                      alignItems: "center",
-                      fontSize: 48,
-                      color: textColors.time,
-                    },
-                    children: publishedAt,
-                  },
-                },
-                {
-                  type: "div",
-                  props: {
-                    style: {
-                      display: "flex",
-                      fontSize: 48,
-                      color: textColors.meta,
-                    },
-                    children: "blog.sh1ma.dev",
-                  },
-                },
-              ],
-            },
-          },
-        ],
+// slug をシードにした決定的な乱数
+const seededRandom = (seed: string) => {
+  let state = 0x811c9dc5
+  for (let i = 0; i < seed.length; i++) {
+    state = Math.imul(state ^ seed.charCodeAt(i), 0x01000193) | 0
+  }
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) | 0
+    return ((state >>> 0) % 0x100000000) / 0x100000000
+  }
+}
+
+const shuffle = <T>(arr: T[], rng: () => number): T[] => {
+  const a = [...arr]
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}
+
+// 4隅の不定形ポリゴンを生成する。各ポリゴンは対応する角と、
+// その角に接する2辺の各1点、内部の2〜3点を経由する五角形〜六角形。
+// これにより「4辺に完全に接する」を担保しつつランダム感を出す
+const buildCornerPolygons = (rng: () => number) => {
+  const rand = (min: number, max: number) => min + rng() * (max - min)
+  const jitter = (base: number, spread: number) =>
+    base + (rng() - 0.5) * 2 * spread
+
+  const palette = shuffle(CORNER_PALETTE, rng)
+
+  // 各コーナー: 辺沿いの延長距離と内部の凹凸点
+  // edgeH: 縦辺方向の延長, edgeW: 横辺方向の延長
+  const buildPoints = (
+    corner: "tl" | "tr" | "bl" | "br",
+    edgeW: number,
+    edgeH: number,
+    innerPts: Array<{ x: number; y: number }>,
+  ) => {
+    // 角の座標
+    const cx = corner === "tl" || corner === "bl" ? 0 : WIDTH
+    const cy = corner === "tl" || corner === "tr" ? 0 : HEIGHT
+    const signX = corner === "tl" || corner === "bl" ? 1 : -1
+    const signY = corner === "tl" || corner === "tr" ? 1 : -1
+
+    // 頂点順: 角 → 横辺沿いの点 → 内部点 → 縦辺沿いの点 → 角 (自動 close)
+    const pts: Array<[number, number]> = [
+      [cx, cy],
+      [cx + signX * edgeW, cy],
+      ...innerPts.map(
+        (p) => [cx + signX * p.x, cy + signY * p.y] as [number, number],
+      ),
+      [cx, cy + signY * edgeH],
+    ]
+    return pts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(" ")
+  }
+
+  // 下側 (bl/br) は下端に載る meta 行を避けるため縦方向を短めに、
+  // 上側 (tl/tr) は多少大きくても OK
+  const corners = (["tl", "tr", "bl", "br"] as const).map((corner, i) => {
+    const isBottom = corner === "bl" || corner === "br"
+    const edgeW = rand(300, 460)
+    const edgeH = isBottom ? rand(120, 200) : rand(220, 340)
+    const innerPts = [
+      { x: jitter(edgeW * 0.72, 40), y: jitter(edgeH * 0.28, 20) },
+      { x: jitter(edgeW * 0.55, 60), y: jitter(edgeH * 0.55, 30) },
+      { x: jitter(edgeW * 0.28, 30), y: jitter(edgeH * 0.78, 20) },
+    ]
+    return {
+      color: palette[i],
+      points: buildPoints(corner, edgeW, edgeH, innerPts),
+    }
+  })
+
+  return corners
+}
+
+const buildNode = (title: string, publishedAt: string, slug: string) => {
+  const rng = seededRandom(slug)
+  const corners = buildCornerPolygons(rng)
+
+  const svgChildren = corners.map((c) => ({
+    type: "polygon",
+    props: { points: c.points, fill: c.color },
+  }))
+
+  return {
+    type: "div",
+    props: {
+      style: {
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        position: "relative",
+        backgroundColor: "white",
+        color: textColors.title,
+        fontFamily: FONT_FAMILY,
       },
+      children: [
+        // 背景の4隅ポリゴン
+        {
+          type: "svg",
+          props: {
+            width: WIDTH,
+            height: HEIGHT,
+            viewBox: `0 0 ${WIDTH} ${HEIGHT}`,
+            style: {
+              position: "absolute",
+              top: 0,
+              left: 0,
+            },
+            children: svgChildren,
+          },
+        },
+        // 前景のテキストレイヤー
+        {
+          type: "div",
+          props: {
+            style: {
+              width: "100%",
+              height: "100%",
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "space-between",
+              padding: "96px 96px 72px",
+              position: "relative",
+            },
+            children: [
+              {
+                type: "div",
+                props: {
+                  style: {
+                    display: "flex",
+                    fontSize: 64,
+                    fontWeight: 600,
+                    lineHeight: 1.25,
+                    marginTop: 48,
+                  },
+                  children: title,
+                },
+              },
+              {
+                type: "div",
+                props: {
+                  style: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-end",
+                    fontSize: 44,
+                  },
+                  children: [
+                    {
+                      type: "div",
+                      props: {
+                        style: { display: "flex", color: textColors.time },
+                        children: publishedAt,
+                      },
+                    },
+                    {
+                      type: "div",
+                      props: {
+                        style: {
+                          display: "flex",
+                          color: textColors.meta,
+                          fontWeight: 600,
+                        },
+                        children: "blog.sh1ma.dev",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
     },
-  },
-})
+  }
+}
 
 const escapeHtml = (s: string) =>
   s
@@ -144,7 +243,7 @@ const renderPng = async (
   publishedAt: string,
   fonts: Awaited<ReturnType<typeof loadFonts>>,
 ) => {
-  const svg = await satori(buildNode(title, publishedAt) as never, {
+  const svg = await satori(buildNode(title, publishedAt, slug) as never, {
     width: WIDTH,
     height: HEIGHT,
     fonts,
@@ -182,7 +281,6 @@ const buildArticleHtml = (
     `    <meta name="twitter:description" content="${escapeHtml(desc)}" />`,
     `    <meta name="twitter:image" content="${ogImage}" />`,
   ].join("\n")
-  // Also override <title>
   const withTitle = shell.replace(
     /<title>[^<]*<\/title>/,
     `<title>${escapeHtml(title)}</title>`,

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -5,7 +5,7 @@ import dayjs from "dayjs"
 import satori from "satori"
 import { allArticles } from "../.contentlayer/generated/index.mjs"
 
-const SITE_URL = "https://blog.sh1ma.dev"
+const SITE_URL = process.env.SITE_URL ?? "https://blog.sh1ma.dev"
 const DIST_DIR = path.resolve("./dist")
 const OG_DIR = path.join(DIST_DIR, "og")
 const SHELL_HTML = path.join(DIST_DIR, "index.html")

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -35,16 +35,17 @@ const textColors = {
 // タイトル最大 3 行 + 日付 / サイト名行が入るサイズ
 const TEXT_ZONE = { x: 60, y: 165, w: WIDTH - 120, h: 300 }
 
-// 図形を置ける 6 個のスロット。TEXT_ZONE と交差しない位置
-type BBox = { x: number; y: number; w: number; h: number }
-const SLOTS: BBox[] = [
-  { x: 40, y: 25, w: 190, h: 120 }, // top-left
-  { x: 505, y: 20, w: 190, h: 120 }, // top-center
-  { x: 970, y: 25, w: 190, h: 120 }, // top-right
-  { x: 40, y: 485, w: 190, h: 120 }, // bottom-left
-  { x: 505, y: 490, w: 190, h: 120 }, // bottom-center
-  { x: 970, y: 485, w: 190, h: 120 }, // bottom-right
-]
+// 上下バンドの余白 (キャンバス外へ多少はみ出しても OK)
+const OVERFLOW_MARGIN = 80
+// バンド幅 (テキスト安全領域の上下、上端 / 下端は overflow 分だけ広げる)
+const TOP_BAND = {
+  yMin: -OVERFLOW_MARGIN,
+  yMax: TEXT_ZONE.y,
+}
+const BOTTOM_BAND = {
+  yMin: TEXT_ZONE.y + TEXT_ZONE.h,
+  yMax: HEIGHT + OVERFLOW_MARGIN,
+}
 
 const loadFonts = async () => {
   return Promise.all(
@@ -86,8 +87,9 @@ const SHAPE_TYPES: readonly ShapeType[] = [
   "geometric",
 ]
 
-// 各スロットの bbox 内に 1 つの図形を返す。返り値は satori 用の
-// SVG ノードツリー
+type BBox = { x: number; y: number; w: number; h: number }
+
+// bbox の中に 1 つの図形を返す
 const buildShape = (
   type: ShapeType,
   bbox: BBox,
@@ -258,20 +260,51 @@ const buildShape = (
   }
 }
 
+// テキスト安全領域と交差しない、上下バンドに散らばった bbox を生成
+const generateShapeBBoxes = (rng: () => number): BBox[] => {
+  const rand = (min: number, max: number) => min + rng() * (max - min)
+  const bboxes: BBox[] = []
+  // 12〜20 個。数もランダム
+  const n = 12 + Math.floor(rng() * 9)
+
+  for (let i = 0; i < n; i++) {
+    // サイズは 70〜240 (円やX などは実サイズより小さくレンダリングされる)
+    const size = rand(70, 240)
+    const half = size / 2
+    // 上バンドか下バンドか (半々くらい)
+    const useTop = rng() < 0.5
+    const band = useTop ? TOP_BAND : BOTTOM_BAND
+
+    // 縦位置: bbox が band 内に入るように選ぶ
+    const cyMin = band.yMin + half
+    const cyMax = band.yMax - half
+    if (cyMax <= cyMin) continue
+    const cy = rand(cyMin, cyMax)
+
+    // 横位置: overflow 許容で左右少しはみ出し
+    const cx = rand(-OVERFLOW_MARGIN + half, WIDTH + OVERFLOW_MARGIN - half)
+
+    bboxes.push({ x: cx - half, y: cy - half, w: size, h: size })
+  }
+  return bboxes
+}
+
 const buildBackgroundSvg = (slug: string) => {
   const rng = seededRandom(slug)
-  // カラーはスロットごとに独立に選ぶ (ただし直前と同じ色は避ける)
+  const bboxes = generateShapeBBoxes(rng)
+
+  // カラーは前と別の色を選ぶ (連続同色を避ける)
   let lastColor: string | null = null
   const pickColor = () => {
     let c: string
     do {
       c = pick(PALETTE, rng)
-    } while (c === lastColor)
+    } while (c === lastColor && PALETTE.length > 1)
     lastColor = c
     return c
   }
 
-  const children = SLOTS.map((bbox) => {
+  const children = bboxes.map((bbox) => {
     const type = pick(SHAPE_TYPES, rng)
     return buildShape(type, bbox, pickColor(), rng)
   })
@@ -282,7 +315,7 @@ const buildBackgroundSvg = (slug: string) => {
       width: WIDTH,
       height: HEIGHT,
       viewBox: `0 0 ${WIDTH} ${HEIGHT}`,
-      style: { position: "absolute", top: 0, left: 0 },
+      style: { position: "absolute", top: 0, left: 0, overflow: "visible" },
       children,
     },
   }

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -33,19 +33,10 @@ const textColors = {
 
 // テキスト安全領域 (この矩形の内側には図形を配置しない)
 // タイトル最大 3 行 + 日付 / サイト名行が入るサイズ
-const TEXT_ZONE = { x: 60, y: 165, w: WIDTH - 120, h: 300 }
+const TEXT_ZONE = { x: 120, y: 175, w: WIDTH - 240, h: 280 }
 
-// 上下バンドの余白 (キャンバス外へ多少はみ出しても OK)
-const OVERFLOW_MARGIN = 80
-// バンド幅 (テキスト安全領域の上下、上端 / 下端は overflow 分だけ広げる)
-const TOP_BAND = {
-  yMin: -OVERFLOW_MARGIN,
-  yMax: TEXT_ZONE.y,
-}
-const BOTTOM_BAND = {
-  yMin: TEXT_ZONE.y + TEXT_ZONE.h,
-  yMax: HEIGHT + OVERFLOW_MARGIN,
-}
+// キャンバス外への overflow 許容量
+const OVERFLOW_MARGIN = 90
 
 const loadFonts = async () => {
   return Promise.all(
@@ -260,31 +251,144 @@ const buildShape = (
   }
 }
 
-// テキスト安全領域と交差しない、上下バンドに散らばった bbox を生成
+// TEXT_ZONE の外周上の点 (パラメータ t で 1 周する) と、外向き法線
+type PerimeterPoint = {
+  x: number
+  y: number
+  nx: number
+  ny: number
+  edge: "top" | "right" | "bottom" | "left"
+  // corner 付近では法線を斜め方向にブレンドしたい
+  cornerBias: number // 0=辺の中央, 1=完全な角
+}
+
+const perimeterAt = (t: number): PerimeterPoint => {
+  const z = TEXT_ZONE
+  const p = 2 * (z.w + z.h)
+  let s = ((t % p) + p) % p
+  const cornerBand = 60 // 角から60px以内は cornerBias が上がる
+
+  const bias = (distToCorner: number) =>
+    Math.max(0, 1 - distToCorner / cornerBand)
+
+  if (s < z.w) {
+    const distCorner = Math.min(s, z.w - s)
+    return {
+      x: z.x + s,
+      y: z.y,
+      nx: 0,
+      ny: -1,
+      edge: "top",
+      cornerBias: bias(distCorner),
+    }
+  }
+  s -= z.w
+  if (s < z.h) {
+    const distCorner = Math.min(s, z.h - s)
+    return {
+      x: z.x + z.w,
+      y: z.y + s,
+      nx: 1,
+      ny: 0,
+      edge: "right",
+      cornerBias: bias(distCorner),
+    }
+  }
+  s -= z.h
+  if (s < z.w) {
+    const distCorner = Math.min(s, z.w - s)
+    return {
+      x: z.x + z.w - s,
+      y: z.y + z.h,
+      nx: 0,
+      ny: 1,
+      edge: "bottom",
+      cornerBias: bias(distCorner),
+    }
+  }
+  s -= z.w
+  const distCorner = Math.min(s, z.h - s)
+  return {
+    x: z.x,
+    y: z.y + z.h - s,
+    nx: -1,
+    ny: 0,
+    edge: "left",
+    cornerBias: bias(distCorner),
+  }
+}
+
+// bbox と TEXT_ZONE の重なり判定
+const intersectsTextZone = (bbox: BBox) => {
+  return (
+    bbox.x < TEXT_ZONE.x + TEXT_ZONE.w &&
+    bbox.x + bbox.w > TEXT_ZONE.x &&
+    bbox.y < TEXT_ZONE.y + TEXT_ZONE.h &&
+    bbox.y + bbox.h > TEXT_ZONE.y
+  )
+}
+
+// 「デザインされたランダム感」: 外周を N 分割し、各セグメントに 1 個ずつ
+// 図形を置く。位置は少しジッター、サイズは 3 段階から傾斜サンプリング
 const generateShapeBBoxes = (rng: () => number): BBox[] => {
   const rand = (min: number, max: number) => min + rng() * (max - min)
+  const p = 2 * (TEXT_ZONE.w + TEXT_ZONE.h)
   const bboxes: BBox[] = []
-  // 12〜20 個。数もランダム
-  const n = 12 + Math.floor(rng() * 9)
+  // 個数: 16〜22
+  const n = 16 + Math.floor(rng() * 7)
 
   for (let i = 0; i < n; i++) {
-    // サイズは 70〜240 (円やX などは実サイズより小さくレンダリングされる)
-    const size = rand(70, 240)
+    // 均等 t + ジッター (隣接セグメントの中央までのみブレる)
+    const baseT = ((i + 0.5) * p) / n
+    const jitterT = (rng() - 0.5) * (p / n) * 0.85
+    const t = baseT + jitterT
+    const pt = perimeterAt(t)
+
+    // サイズ分布: 小さめ 20% / 中 55% / 大 25%
+    const r = rng()
+    let size: number
+    if (r < 0.2) size = rand(50, 90)
+    else if (r < 0.75) size = rand(90, 160)
+    else size = rand(160, 230)
     const half = size / 2
-    // 上バンドか下バンドか (半々くらい)
-    const useTop = rng() < 0.5
-    const band = useTop ? TOP_BAND : BOTTOM_BAND
 
-    // 縦位置: bbox が band 内に入るように選ぶ
-    const cyMin = band.yMin + half
-    const cyMax = band.yMax - half
-    if (cyMax <= cyMin) continue
-    const cy = rand(cyMin, cyMax)
+    // 外向きに押し出す距離。half より少し多めで、少しジッター
+    const push = half + rand(0, 55)
 
-    // 横位置: overflow 許容で左右少しはみ出し
-    const cx = rand(-OVERFLOW_MARGIN + half, WIDTH + OVERFLOW_MARGIN - half)
+    // 角付近では法線を斜めに寄せる (辺方向の tangent 成分を混ぜる)
+    // top/bottom 辺の tangent は ±x, left/right の tangent は ±y
+    let nx = pt.nx
+    let ny = pt.ny
+    if (pt.cornerBias > 0) {
+      // どちらのコーナー寄りか (辺の前半 or 後半)
+      // ここでは単純に「角の近く」の場合、tangent 成分を追加して斜めにする
+      const tangentSign = rng() < 0.5 ? 1 : -1
+      const tx = pt.edge === "top" || pt.edge === "bottom" ? tangentSign : 0
+      const ty = pt.edge === "left" || pt.edge === "right" ? tangentSign : 0
+      const w = pt.cornerBias * 0.9
+      nx = nx * (1 - w) + tx * w
+      ny = ny * (1 - w) + ty * w
+      const mag = Math.hypot(nx, ny) || 1
+      nx /= mag
+      ny /= mag
+    }
 
-    bboxes.push({ x: cx - half, y: cy - half, w: size, h: size })
+    const cx = pt.x + nx * push
+    const cy = pt.y + ny * push
+
+    const bbox = { x: cx - half, y: cy - half, w: size, h: size }
+    // 念のためテキスト領域と重なる場合はスキップ
+    if (intersectsTextZone(bbox)) continue
+    // キャンバス外側にほとんど出過ぎているものもスキップ
+    if (
+      bbox.x + bbox.w < -OVERFLOW_MARGIN ||
+      bbox.x > WIDTH + OVERFLOW_MARGIN ||
+      bbox.y + bbox.h < -OVERFLOW_MARGIN ||
+      bbox.y > HEIGHT + OVERFLOW_MARGIN
+    ) {
+      continue
+    }
+    bboxes.push(bbox)
   }
   return bboxes
 }

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -103,7 +103,8 @@ const buildShape = (
   const rand = (min: number, max: number) => min + rng() * (max - min)
   const cx = x + w / 2
   const cy = y + h / 2
-  const rotation = rand(-180, 180)
+  // 柄っぽさを維持するため、回転は控えめ (±25°)
+  const rotation = rand(-25, 25)
 
   const buildElement = () => {
     if (type === "triangle") {
@@ -273,168 +274,136 @@ const intersectsTextZone = (bbox: BBox) => {
   )
 }
 
-// 外周を 4 バンドに分け、それぞれに図形を密に配置する。
-// - 上下 (横に長い): 多くの図形
-// - 左右 (縦に長い、幅は狭い): 少なめだが必ず存在
-// - サイズと位置はジッター、キャンバス端に到達 (overflow) しやすい
-type Band = "top" | "right" | "bottom" | "left"
+// 図形は "柄" として扱う。上下左右のストリップにグリッド + ジッタで並べる
+type ShapeSpec = { bbox: BBox; kind: "free" }
 
-const bandExtents = (band: Band) => {
-  const O = OVERFLOW_MARGIN
-  if (band === "top") {
-    return { xMin: -O, xMax: WIDTH + O, yMin: -O, yMax: TEXT_ZONE.y }
-  }
-  if (band === "bottom") {
-    return {
-      xMin: -O,
-      xMax: WIDTH + O,
-      yMin: TEXT_ZONE.y + TEXT_ZONE.h,
-      yMax: HEIGHT + O,
-    }
-  }
-  if (band === "left") {
-    return {
-      xMin: -O,
-      xMax: TEXT_ZONE.x,
-      yMin: TEXT_ZONE.y,
-      yMax: TEXT_ZONE.y + TEXT_ZONE.h,
-    }
-  }
-  return {
-    xMin: TEXT_ZONE.x + TEXT_ZONE.w,
-    xMax: WIDTH + O,
-    yMin: TEXT_ZONE.y,
-    yMax: TEXT_ZONE.y + TEXT_ZONE.h,
-  }
-}
-
-// 与えられた band 内にランダムに 1 個の bbox を返す (テキスト領域と非交差)
-const sampleInBand = (
-  band: Band,
-  size: number,
-  rand: (a: number, b: number) => number,
-): BBox | null => {
-  const ext = bandExtents(band)
-  const half = size / 2
-  const availW = ext.xMax - ext.xMin
-  const availH = ext.yMax - ext.yMin
-  if (availW < 20 || availH < 20) return null
-  // half がバンド寸法より大きいときは "半分以上はみ出す" 状態を許容するので、
-  // 中心座標を band 範囲でクランプ
-  const cxMin = ext.xMin + Math.min(half, availW / 2 - 10)
-  const cxMax = ext.xMax - Math.min(half, availW / 2 - 10)
-  const cyMin = ext.yMin + Math.min(half, availH / 2 - 10)
-  const cyMax = ext.yMax - Math.min(half, availH / 2 - 10)
-  const cx = rand(cxMin, cxMax)
-  const cy = rand(cyMin, cyMax)
-  const bbox: BBox = { x: cx - half, y: cy - half, w: size, h: size }
-  if (intersectsTextZone(bbox)) return null
-  return bbox
-}
-
-const pickSize = (
+// 1 ストリップ内にグリッドで図形を並べる。
+// nCols/nRows でセル数、cellSize でセル 1 個の一辺、jitter でセル内の揺らぎ、
+// shapeMin/shapeMax でセル内の実サイズ範囲
+const placeGrid = (
   rng: () => number,
   rand: (a: number, b: number) => number,
+  opts: {
+    xStart: number
+    xEnd: number
+    yStart: number
+    yEnd: number
+    cell: number
+    jitter: number
+    shapeMin: number
+    shapeMax: number
+    staggerRows?: boolean
+  },
+  specs: ShapeSpec[],
 ) => {
-  const r = rng()
-  if (r < 0.2) return rand(50, 90) // 小 (点描)
-  if (r < 0.7) return rand(90, 170) // 中
-  if (r < 0.92) return rand(170, 240) // 大
-  return rand(240, 320) // 特大アクセント
-}
+  const width = opts.xEnd - opts.xStart
+  const height = opts.yEnd - opts.yStart
+  const nCols = Math.max(1, Math.round(width / opts.cell))
+  const nRows = Math.max(1, Math.round(height / opts.cell))
+  const stepX = width / nCols
+  const stepY = height / nRows
 
-// 図形の分類: "anchor" は canvas 端に必ず接触させる図形 (回転なし・bbox 一杯)
-// "free" は装飾的な自由配置図形 (回転あり)
-type ShapeSpec = { bbox: BBox; kind: "anchor" | "free"; edge?: Edge }
-type Edge = "top" | "bottom" | "left" | "right"
+  for (let r = 0; r < nRows; r++) {
+    const rowShift = opts.staggerRows && r % 2 === 1 ? stepX * 0.5 : 0
+    for (let c = 0; c < nCols; c++) {
+      const cx =
+        opts.xStart +
+        (c + 0.5) * stepX +
+        rowShift +
+        rand(-opts.jitter, opts.jitter)
+      const cy =
+        opts.yStart + (r + 0.5) * stepY + rand(-opts.jitter, opts.jitter)
+      const size = rand(opts.shapeMin, opts.shapeMax)
+      const half = size / 2
+      const bbox = { x: cx - half, y: cy - half, w: size, h: size }
+      if (intersectsTextZone(bbox)) continue
+      specs.push({ bbox, kind: "free" })
+    }
+    // 未使用パラメータ警告を避ける
+    void rng
+  }
+}
 
 const generateShapeSpecs = (rng: () => number): ShapeSpec[] => {
   const rand = (min: number, max: number) => min + rng() * (max - min)
   const specs: ShapeSpec[] = []
 
-  // ------ 1. Edge anchors: 各辺に 5〜7 個、必ず canvas 端をまたぐ ------
-  const edges: Edge[] = ["top", "bottom", "left", "right"]
-  for (const edge of edges) {
-    const isHorizontal = edge === "top" || edge === "bottom"
-    const anchorCount = 5 + Math.floor(rng() * 3) // 5〜7
+  const O = OVERFLOW_MARGIN
+  const CELL = 140 // グリッドの一辺 (図形間の中心間隔)
+  const JITTER = 14 // セル内のランダム変位 (柄が揺らぐ程度)
+  // 図形サイズはセルの 45〜75% (被らないよう控えめ)
+  const SHAPE_MIN = CELL * 0.45
+  const SHAPE_MAX = CELL * 0.72
 
-    for (let i = 0; i < anchorCount; i++) {
-      // 辺方向に均等分布 + ジッター
-      const baseT = (i + 0.5) / anchorCount
-      const jitterT = (rng() - 0.5) * (1 / anchorCount) * 0.9
-      const t = Math.max(0.02, Math.min(0.98, baseT + jitterT))
-      const size = rand(90, 210)
-      const half = size / 2
-
-      let cx: number, cy: number
-      if (isHorizontal) {
-        cx = t * WIDTH
-        // 中心 Y は canvas 端 (y=0 か y=HEIGHT) の外側 30〜(half-20) にする
-        // → bbox が確実に端 (y=0 or y=HEIGHT) をまたぐ
-        const outside = rand(20, half - 25)
-        cy = edge === "top" ? -outside : HEIGHT + outside
-      } else {
-        // 縦辺は TEXT_ZONE の高さ範囲内に配置
-        cy = TEXT_ZONE.y + t * TEXT_ZONE.h
-        const outside = rand(20, half - 25)
-        cx = edge === "left" ? -outside : WIDTH + outside
-      }
-
-      const bbox = { x: cx - half, y: cy - half, w: size, h: size }
-      if (intersectsTextZone(bbox)) continue
-      specs.push({ bbox, kind: "anchor", edge })
-    }
-  }
-
-  // ------ 2. Free-form 装飾: 4 バンドに追加で散らばす ------
-  const counts: Record<Band, number> = {
-    top: 10 + Math.floor(rng() * 4),
-    bottom: 10 + Math.floor(rng() * 4),
-    left: 4 + Math.floor(rng() * 3),
-    right: 4 + Math.floor(rng() * 3),
-  }
-  const bands: Band[] = ["top", "bottom", "left", "right"]
-  for (const band of bands) {
-    for (let i = 0; i < counts[band]; i++) {
-      for (let attempt = 0; attempt < 6; attempt++) {
-        const size = pickSize(rng, rand)
-        const bbox = sampleInBand(band, size, rand)
-        if (bbox) {
-          specs.push({ bbox, kind: "free" })
-          break
-        }
-      }
-    }
-  }
-  return specs
-}
-
-// anchor 用: bbox 一杯の楕円 or 矩形。回転なし、canvas 端まで確実に届く
-const buildAnchorShape = (bbox: BBox, color: string, rng: () => number) => {
-  // 楕円 60% / 矩形 40% で振り分け (共に bbox 一杯)
-  if (rng() < 0.6) {
-    return {
-      type: "ellipse",
-      props: {
-        cx: bbox.x + bbox.w / 2,
-        cy: bbox.y + bbox.h / 2,
-        rx: bbox.w / 2,
-        ry: bbox.h / 2,
-        fill: color,
-      },
-    }
-  }
-  return {
-    type: "rect",
-    props: {
-      x: bbox.x,
-      y: bbox.y,
-      width: bbox.w,
-      height: bbox.h,
-      rx: rng() < 0.3 ? 12 : 0,
-      fill: color,
+  // Top strip: canvas 端から少しはみ出させて 2 行
+  placeGrid(
+    rng,
+    rand,
+    {
+      xStart: -O + 20,
+      xEnd: WIDTH + O - 20,
+      yStart: -O + 20,
+      yEnd: TEXT_ZONE.y - 15,
+      cell: CELL,
+      jitter: JITTER,
+      shapeMin: SHAPE_MIN,
+      shapeMax: SHAPE_MAX,
+      staggerRows: true,
     },
-  }
+    specs,
+  )
+  // Bottom strip
+  placeGrid(
+    rng,
+    rand,
+    {
+      xStart: -O + 20,
+      xEnd: WIDTH + O - 20,
+      yStart: TEXT_ZONE.y + TEXT_ZONE.h + 15,
+      yEnd: HEIGHT + O - 20,
+      cell: CELL,
+      jitter: JITTER,
+      shapeMin: SHAPE_MIN,
+      shapeMax: SHAPE_MAX,
+      staggerRows: true,
+    },
+    specs,
+  )
+  // Left column
+  placeGrid(
+    rng,
+    rand,
+    {
+      xStart: -O + 20,
+      xEnd: TEXT_ZONE.x - 15,
+      yStart: TEXT_ZONE.y + 15,
+      yEnd: TEXT_ZONE.y + TEXT_ZONE.h - 15,
+      cell: CELL,
+      jitter: JITTER,
+      shapeMin: SHAPE_MIN,
+      shapeMax: SHAPE_MAX,
+      staggerRows: true,
+    },
+    specs,
+  )
+  // Right column
+  placeGrid(
+    rng,
+    rand,
+    {
+      xStart: TEXT_ZONE.x + TEXT_ZONE.w + 15,
+      xEnd: WIDTH + O - 20,
+      yStart: TEXT_ZONE.y + 15,
+      yEnd: TEXT_ZONE.y + TEXT_ZONE.h - 15,
+      cell: CELL,
+      jitter: JITTER,
+      shapeMin: SHAPE_MIN,
+      shapeMax: SHAPE_MAX,
+      staggerRows: true,
+    },
+    specs,
+  )
+  return specs
 }
 
 const buildBackgroundSvg = (slug: string) => {
@@ -454,9 +423,6 @@ const buildBackgroundSvg = (slug: string) => {
 
   const children = specs.map((spec) => {
     const color = pickColor()
-    if (spec.kind === "anchor") {
-      return buildAnchorShape(spec.bbox, color, rng)
-    }
     const type = pick(SHAPE_TYPES, rng)
     return buildShape(type, spec.bbox, color, rng)
   })

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -343,86 +343,103 @@ const pickSize = (
   return rand(240, 320) // 特大アクセント
 }
 
-const generateShapeBBoxes = (rng: () => number): BBox[] => {
-  const rand = (min: number, max: number) => min + rng() * (max - min)
-  const bboxes: BBox[] = []
+// 図形の分類: "anchor" は canvas 端に必ず接触させる図形 (回転なし・bbox 一杯)
+// "free" は装飾的な自由配置図形 (回転あり)
+type ShapeSpec = { bbox: BBox; kind: "anchor" | "free"; edge?: Edge }
+type Edge = "top" | "bottom" | "left" | "right"
 
-  // 各辺に必ず十分な数を割り当てる
-  // 上下: 12〜16 個ずつ、左右: 5〜8 個ずつ → 合計 34〜48 個
-  const counts: Record<Band, number> = {
-    top: 12 + Math.floor(rng() * 5),
-    bottom: 12 + Math.floor(rng() * 5),
-    left: 5 + Math.floor(rng() * 4),
-    right: 5 + Math.floor(rng() * 4),
+const generateShapeSpecs = (rng: () => number): ShapeSpec[] => {
+  const rand = (min: number, max: number) => min + rng() * (max - min)
+  const specs: ShapeSpec[] = []
+
+  // ------ 1. Edge anchors: 各辺に 5〜7 個、必ず canvas 端をまたぐ ------
+  const edges: Edge[] = ["top", "bottom", "left", "right"]
+  for (const edge of edges) {
+    const isHorizontal = edge === "top" || edge === "bottom"
+    const anchorCount = 5 + Math.floor(rng() * 3) // 5〜7
+
+    for (let i = 0; i < anchorCount; i++) {
+      // 辺方向に均等分布 + ジッター
+      const baseT = (i + 0.5) / anchorCount
+      const jitterT = (rng() - 0.5) * (1 / anchorCount) * 0.9
+      const t = Math.max(0.02, Math.min(0.98, baseT + jitterT))
+      const size = rand(90, 210)
+      const half = size / 2
+
+      let cx: number, cy: number
+      if (isHorizontal) {
+        cx = t * WIDTH
+        // 中心 Y は canvas 端 (y=0 か y=HEIGHT) の外側 30〜(half-20) にする
+        // → bbox が確実に端 (y=0 or y=HEIGHT) をまたぐ
+        const outside = rand(20, half - 25)
+        cy = edge === "top" ? -outside : HEIGHT + outside
+      } else {
+        // 縦辺は TEXT_ZONE の高さ範囲内に配置
+        cy = TEXT_ZONE.y + t * TEXT_ZONE.h
+        const outside = rand(20, half - 25)
+        cx = edge === "left" ? -outside : WIDTH + outside
+      }
+
+      const bbox = { x: cx - half, y: cy - half, w: size, h: size }
+      if (intersectsTextZone(bbox)) continue
+      specs.push({ bbox, kind: "anchor", edge })
+    }
   }
 
+  // ------ 2. Free-form 装飾: 4 バンドに追加で散らばす ------
+  const counts: Record<Band, number> = {
+    top: 10 + Math.floor(rng() * 4),
+    bottom: 10 + Math.floor(rng() * 4),
+    left: 4 + Math.floor(rng() * 3),
+    right: 4 + Math.floor(rng() * 3),
+  }
   const bands: Band[] = ["top", "bottom", "left", "right"]
   for (const band of bands) {
     for (let i = 0; i < counts[band]; i++) {
-      // 十分な回数試行 (テキスト非交差の bbox を得るため)
       for (let attempt = 0; attempt < 6; attempt++) {
         const size = pickSize(rng, rand)
         const bbox = sampleInBand(band, size, rand)
         if (bbox) {
-          bboxes.push(bbox)
+          specs.push({ bbox, kind: "free" })
           break
         }
       }
     }
   }
+  return specs
+}
 
-  // 4 辺すべてに canvas 端に接する図形が最低 1 個は欲しい
-  // (中心を端 or 端の少し外に置いて、bbox が端をまたぐようにする)
-  const ensureEdgeContact: {
-    edge: "top" | "bottom" | "left" | "right"
-    band: Band
-  }[] = [
-    { edge: "top", band: "top" },
-    { edge: "bottom", band: "bottom" },
-    { edge: "left", band: "left" },
-    { edge: "right", band: "right" },
-  ]
-  for (const { edge, band } of ensureEdgeContact) {
-    // 既に接している bbox があるかチェック
-    const hasContact = bboxes.some((b) => {
-      if (edge === "top") return b.y <= 0
-      if (edge === "bottom") return b.y + b.h >= HEIGHT
-      if (edge === "left") return b.x <= 0
-      return b.x + b.w >= WIDTH
-    })
-    if (hasContact) continue
-    // 端を跨ぐ図形を無理やり追加
-    for (let attempt = 0; attempt < 20; attempt++) {
-      const size = rand(140, 220)
-      const half = size / 2
-      let cx: number, cy: number
-      if (edge === "top" || edge === "bottom") {
-        cx = rand(80, WIDTH - 80)
-        cy =
-          edge === "top"
-            ? rand(-half + 15, -20)
-            : rand(HEIGHT + 20, HEIGHT + half - 15)
-      } else {
-        cy = rand(TEXT_ZONE.y + 20, TEXT_ZONE.y + TEXT_ZONE.h - 20)
-        cx =
-          edge === "left"
-            ? rand(-half + 15, -20)
-            : rand(WIDTH + 20, WIDTH + half - 15)
-      }
-      const bbox: BBox = { x: cx - half, y: cy - half, w: size, h: size }
-      if (intersectsTextZone(bbox)) continue
-      bboxes.push(bbox)
-      break
+// anchor 用: bbox 一杯の楕円 or 矩形。回転なし、canvas 端まで確実に届く
+const buildAnchorShape = (bbox: BBox, color: string, rng: () => number) => {
+  // 楕円 60% / 矩形 40% で振り分け (共に bbox 一杯)
+  if (rng() < 0.6) {
+    return {
+      type: "ellipse",
+      props: {
+        cx: bbox.x + bbox.w / 2,
+        cy: bbox.y + bbox.h / 2,
+        rx: bbox.w / 2,
+        ry: bbox.h / 2,
+        fill: color,
+      },
     }
-    void band
   }
-
-  return bboxes
+  return {
+    type: "rect",
+    props: {
+      x: bbox.x,
+      y: bbox.y,
+      width: bbox.w,
+      height: bbox.h,
+      rx: rng() < 0.3 ? 12 : 0,
+      fill: color,
+    },
+  }
 }
 
 const buildBackgroundSvg = (slug: string) => {
   const rng = seededRandom(slug)
-  const bboxes = generateShapeBBoxes(rng)
+  const specs = generateShapeSpecs(rng)
 
   // カラーは前と別の色を選ぶ (連続同色を避ける)
   let lastColor: string | null = null
@@ -435,9 +452,13 @@ const buildBackgroundSvg = (slug: string) => {
     return c
   }
 
-  const children = bboxes.map((bbox) => {
+  const children = specs.map((spec) => {
+    const color = pickColor()
+    if (spec.kind === "anchor") {
+      return buildAnchorShape(spec.bbox, color, rng)
+    }
     const type = pick(SHAPE_TYPES, rng)
-    return buildShape(type, bbox, pickColor(), rng)
+    return buildShape(type, spec.bbox, color, rng)
   })
 
   return {

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -11,26 +11,40 @@ const OG_DIR = path.join(DIST_DIR, "og")
 const SHELL_HTML = path.join(DIST_DIR, "index.html")
 const WIDTH = 1200
 const HEIGHT = 630
-const FONT_FAMILY = "IBM Plex Sans JP"
+const FONT_FAMILY = "Zen Maru Gothic"
 
 const FONT_URLS = [
   {
     weight: 400 as const,
-    url: "https://fonts.gstatic.com/s/ibmplexsansjp/v5/Z9XNDn9KbTDf6_f7dISNqYf_tvPT1Cr4iNJ-pwc.ttf",
+    url: "https://fonts.gstatic.com/s/zenmarugothic/v19/o-0SIpIxzW5b-RxT-6A8jWAtCp-k7Q.ttf",
   },
   {
-    weight: 600 as const,
-    url: "https://fonts.gstatic.com/s/ibmplexsansjp/v5/Z9XKDn9KbTDf6_f7dISNqYf_tvPT7PLWrNpVuw5_BAM.ttf",
+    weight: 700 as const,
+    url: "https://fonts.gstatic.com/s/zenmarugothic/v19/o-0XIpIxzW5b-RxT-6A8jWAtCp-cUW1CPA.ttf",
   },
 ]
 
-// 元のグラデーション枠と揃えた4色。角ごとにシャッフルされる
-const CORNER_PALETTE = ["#6365f7", "#f8dbe9", "#afdee8", "#b8bdf2"]
+const PALETTE = ["#6365f7", "#f8dbe9", "#afdee8", "#b8bdf2"]
 const textColors = {
   title: "#303036",
   meta: "#6365f7",
-  time: "#b8bdf2",
+  time: "#8f92c9",
 }
+
+// テキスト安全領域 (この矩形の内側には図形を配置しない)
+// タイトル最大 3 行 + 日付 / サイト名行が入るサイズ
+const TEXT_ZONE = { x: 60, y: 165, w: WIDTH - 120, h: 300 }
+
+// 図形を置ける 6 個のスロット。TEXT_ZONE と交差しない位置
+type BBox = { x: number; y: number; w: number; h: number }
+const SLOTS: BBox[] = [
+  { x: 40, y: 25, w: 190, h: 120 }, // top-left
+  { x: 505, y: 20, w: 190, h: 120 }, // top-center
+  { x: 970, y: 25, w: 190, h: 120 }, // top-right
+  { x: 40, y: 485, w: 190, h: 120 }, // bottom-left
+  { x: 505, y: 490, w: 190, h: 120 }, // bottom-center
+  { x: 970, y: 485, w: 190, h: 120 }, // bottom-right
+]
 
 const loadFonts = async () => {
   return Promise.all(
@@ -50,7 +64,6 @@ const loadFonts = async () => {
   )
 }
 
-// slug をシードにした決定的な乱数
 const seededRandom = (seed: string) => {
   let state = 0x811c9dc5
   for (let i = 0; i < seed.length; i++) {
@@ -62,79 +75,221 @@ const seededRandom = (seed: string) => {
   }
 }
 
-const shuffle = <T>(arr: T[], rng: () => number): T[] => {
-  const a = [...arr]
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1))
-    ;[a[i], a[j]] = [a[j], a[i]]
-  }
-  return a
-}
+const pick = <T>(arr: readonly T[], rng: () => number): T =>
+  arr[Math.floor(rng() * arr.length)]
 
-// 4隅の不定形ポリゴンを生成する。各ポリゴンは対応する角と、
-// その角に接する2辺の各1点、内部の2〜3点を経由する五角形〜六角形。
-// これにより「4辺に完全に接する」を担保しつつランダム感を出す
-const buildCornerPolygons = (rng: () => number) => {
+type ShapeType = "triangle" | "ellipse" | "rectangle" | "geometric"
+const SHAPE_TYPES: readonly ShapeType[] = [
+  "triangle",
+  "ellipse",
+  "rectangle",
+  "geometric",
+]
+
+// 各スロットの bbox 内に 1 つの図形を返す。返り値は satori 用の
+// SVG ノードツリー
+const buildShape = (
+  type: ShapeType,
+  bbox: BBox,
+  color: string,
+  rng: () => number,
+) => {
+  const { x, y, w, h } = bbox
   const rand = (min: number, max: number) => min + rng() * (max - min)
-  const jitter = (base: number, spread: number) =>
-    base + (rng() - 0.5) * 2 * spread
 
-  const palette = shuffle(CORNER_PALETTE, rng)
-
-  // 各コーナー: 辺沿いの延長距離と内部の凹凸点
-  // edgeH: 縦辺方向の延長, edgeW: 横辺方向の延長
-  const buildPoints = (
-    corner: "tl" | "tr" | "bl" | "br",
-    edgeW: number,
-    edgeH: number,
-    innerPts: Array<{ x: number; y: number }>,
-  ) => {
-    // 角の座標
-    const cx = corner === "tl" || corner === "bl" ? 0 : WIDTH
-    const cy = corner === "tl" || corner === "tr" ? 0 : HEIGHT
-    const signX = corner === "tl" || corner === "bl" ? 1 : -1
-    const signY = corner === "tl" || corner === "tr" ? 1 : -1
-
-    // 頂点順: 角 → 横辺沿いの点 → 内部点 → 縦辺沿いの点 → 角 (自動 close)
-    const pts: Array<[number, number]> = [
-      [cx, cy],
-      [cx + signX * edgeW, cy],
-      ...innerPts.map(
-        (p) => [cx + signX * p.x, cy + signY * p.y] as [number, number],
-      ),
-      [cx, cy + signY * edgeH],
-    ]
-    return pts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(" ")
+  if (type === "triangle") {
+    // bbox 底辺の 2 点 + 上辺のどこか 1 点 (二等辺気味〜スケール気味)
+    const p1 = [x + rand(0, w * 0.25), y + h]
+    const p2 = [x + w - rand(0, w * 0.25), y + h]
+    const p3 = [x + rand(0.3, 0.7) * w, y + rand(0, w * 0.15)]
+    return {
+      type: "polygon",
+      props: {
+        points: [p1, p2, p3].map(([px, py]) => `${px},${py}`).join(" "),
+        fill: color,
+      },
+    }
   }
 
-  // 下側 (bl/br) は下端に載る meta 行を避けるため縦方向を短めに、
-  // 上側 (tl/tr) は多少大きくても OK
-  const corners = (["tl", "tr", "bl", "br"] as const).map((corner, i) => {
-    const isBottom = corner === "bl" || corner === "br"
-    const edgeW = rand(300, 460)
-    const edgeH = isBottom ? rand(120, 200) : rand(220, 340)
-    const innerPts = [
-      { x: jitter(edgeW * 0.72, 40), y: jitter(edgeH * 0.28, 20) },
-      { x: jitter(edgeW * 0.55, 60), y: jitter(edgeH * 0.55, 30) },
-      { x: jitter(edgeW * 0.28, 30), y: jitter(edgeH * 0.78, 20) },
+  if (type === "ellipse") {
+    return {
+      type: "ellipse",
+      props: {
+        cx: x + w / 2,
+        cy: y + h / 2,
+        rx: (w / 2) * rand(0.75, 1),
+        ry: (h / 2) * rand(0.75, 1),
+        fill: color,
+      },
+    }
+  }
+
+  if (type === "rectangle") {
+    // 一部を角丸にしてバリエーションを出す
+    const rectW = w * rand(0.6, 0.95)
+    const rectH = h * rand(0.6, 0.95)
+    return {
+      type: "rect",
+      props: {
+        x: x + (w - rectW) / 2,
+        y: y + (h - rectH) / 2,
+        width: rectW,
+        height: rectH,
+        rx: rng() < 0.4 ? rand(10, 24) : 0,
+        fill: color,
+      },
+    }
+  }
+
+  // geometric: 円環 / 十字 / 菱形 / X のいずれか
+  const variant = Math.floor(rng() * 4)
+  const cx = x + w / 2
+  const cy = y + h / 2
+  const r = Math.min(w, h) / 2
+
+  if (variant === 0) {
+    // ring (輪郭のみの円)
+    return {
+      type: "circle",
+      props: {
+        cx,
+        cy,
+        r: r * 0.85,
+        fill: "transparent",
+        stroke: color,
+        strokeWidth: rand(12, 18),
+      },
+    }
+  }
+
+  if (variant === 1) {
+    // plus (+)
+    const armLong = r * 1.7
+    const armShort = r * 0.55
+    return {
+      type: "g",
+      props: {
+        children: [
+          {
+            type: "rect",
+            props: {
+              x: cx - armLong / 2,
+              y: cy - armShort / 2,
+              width: armLong,
+              height: armShort,
+              fill: color,
+            },
+          },
+          {
+            type: "rect",
+            props: {
+              x: cx - armShort / 2,
+              y: cy - armLong / 2,
+              width: armShort,
+              height: armLong,
+              fill: color,
+            },
+          },
+        ],
+      },
+    }
+  }
+
+  if (variant === 2) {
+    // diamond (回転四角)
+    const rx = r * 0.9
+    const ry = r * 0.75
+    const pts = [
+      [cx, cy - ry],
+      [cx + rx, cy],
+      [cx, cy + ry],
+      [cx - rx, cy],
     ]
     return {
-      color: palette[i],
-      points: buildPoints(corner, edgeW, edgeH, innerPts),
+      type: "polygon",
+      props: {
+        points: pts.map(([px, py]) => `${px},${py}`).join(" "),
+        fill: color,
+      },
     }
+  }
+
+  // variant 3: X 型 (2 本の細長い長方形を回転させたポリゴン)
+  const thick = r * 0.35
+  const long = r * 1.6
+  // 45 度回転で 2 本のバーを描く。ここではポリゴンで表現
+  const s = Math.SQRT1_2
+  const arm = long / 2
+  const t = thick / 2
+  // バー1: 左上 → 右下方向
+  const bar1 = [
+    [cx - arm * s - t * s, cy - arm * s + t * s],
+    [cx - arm * s + t * s, cy - arm * s - t * s],
+    [cx + arm * s + t * s, cy + arm * s - t * s],
+    [cx + arm * s - t * s, cy + arm * s + t * s],
+  ]
+  // バー2: 右上 → 左下方向
+  const bar2 = [
+    [cx + arm * s - t * s, cy - arm * s - t * s],
+    [cx + arm * s + t * s, cy - arm * s + t * s],
+    [cx - arm * s + t * s, cy + arm * s + t * s],
+    [cx - arm * s - t * s, cy + arm * s - t * s],
+  ]
+  return {
+    type: "g",
+    props: {
+      children: [
+        {
+          type: "polygon",
+          props: {
+            points: bar1.map(([px, py]) => `${px},${py}`).join(" "),
+            fill: color,
+          },
+        },
+        {
+          type: "polygon",
+          props: {
+            points: bar2.map(([px, py]) => `${px},${py}`).join(" "),
+            fill: color,
+          },
+        },
+      ],
+    },
+  }
+}
+
+const buildBackgroundSvg = (slug: string) => {
+  const rng = seededRandom(slug)
+  // カラーはスロットごとに独立に選ぶ (ただし直前と同じ色は避ける)
+  let lastColor: string | null = null
+  const pickColor = () => {
+    let c: string
+    do {
+      c = pick(PALETTE, rng)
+    } while (c === lastColor)
+    lastColor = c
+    return c
+  }
+
+  const children = SLOTS.map((bbox) => {
+    const type = pick(SHAPE_TYPES, rng)
+    return buildShape(type, bbox, pickColor(), rng)
   })
 
-  return corners
+  return {
+    type: "svg",
+    props: {
+      width: WIDTH,
+      height: HEIGHT,
+      viewBox: `0 0 ${WIDTH} ${HEIGHT}`,
+      style: { position: "absolute", top: 0, left: 0 },
+      children,
+    },
+  }
 }
 
 const buildNode = (title: string, publishedAt: string, slug: string) => {
-  const rng = seededRandom(slug)
-  const corners = buildCornerPolygons(rng)
-
-  const svgChildren = corners.map((c) => ({
-    type: "polygon",
-    props: { points: c.points, fill: c.color },
-  }))
+  const bgSvg = buildBackgroundSvg(slug)
 
   return {
     type: "div",
@@ -149,21 +304,7 @@ const buildNode = (title: string, publishedAt: string, slug: string) => {
         fontFamily: FONT_FAMILY,
       },
       children: [
-        // 背景の4隅ポリゴン
-        {
-          type: "svg",
-          props: {
-            width: WIDTH,
-            height: HEIGHT,
-            viewBox: `0 0 ${WIDTH} ${HEIGHT}`,
-            style: {
-              position: "absolute",
-              top: 0,
-              left: 0,
-            },
-            children: svgChildren,
-          },
-        },
+        bgSvg,
         // 前景のテキストレイヤー
         {
           type: "div",
@@ -174,7 +315,9 @@ const buildNode = (title: string, publishedAt: string, slug: string) => {
               display: "flex",
               flexDirection: "column",
               justifyContent: "space-between",
-              padding: "96px 96px 72px",
+              padding: `${TEXT_ZONE.y}px ${TEXT_ZONE.x}px ${
+                HEIGHT - (TEXT_ZONE.y + TEXT_ZONE.h)
+              }px`,
               position: "relative",
             },
             children: [
@@ -183,10 +326,9 @@ const buildNode = (title: string, publishedAt: string, slug: string) => {
                 props: {
                   style: {
                     display: "flex",
-                    fontSize: 64,
-                    fontWeight: 600,
+                    fontSize: 54,
+                    fontWeight: 700,
                     lineHeight: 1.25,
-                    marginTop: 48,
                   },
                   children: title,
                 },
@@ -198,7 +340,7 @@ const buildNode = (title: string, publishedAt: string, slug: string) => {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "flex-end",
-                    fontSize: 44,
+                    fontSize: 36,
                   },
                   children: [
                     {
@@ -214,7 +356,7 @@ const buildNode = (title: string, publishedAt: string, slug: string) => {
                         style: {
                           display: "flex",
                           color: textColors.meta,
-                          fontWeight: 600,
+                          fontWeight: 700,
                         },
                         children: "blog.sh1ma.dev",
                       },

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -92,7 +92,48 @@ const withRotation = (elem: unknown, cx: number, cy: number, angle: number) => {
   }
 }
 
-// bbox の中に 1 つの図形を返す (ランダム回転付き)
+// 角丸のかかる比率 (図形の代表サイズに対して)。全種で共通の "同じ程度" の丸み
+const RADIUS_RATIO = 0.18
+
+// N 個の頂点で構成される多角形の頂点列に、共通半径 r で角丸を付けた SVG path
+// (二次ベジェで角を丸める)
+const roundedPolygonPath = (points: [number, number][], r: number): string => {
+  const n = points.length
+  const parts: string[] = []
+  for (let i = 0; i < n; i++) {
+    const prev = points[(i - 1 + n) % n]
+    const curr = points[i]
+    const next = points[(i + 1) % n]
+
+    const dxIn = prev[0] - curr[0]
+    const dyIn = prev[1] - curr[1]
+    const inLen = Math.hypot(dxIn, dyIn) || 1
+    const dxOut = next[0] - curr[0]
+    const dyOut = next[1] - curr[1]
+    const outLen = Math.hypot(dxOut, dyOut) || 1
+
+    // 隣接辺の長さで丸め半径を制限 (辺の中点を超えない)
+    const rr = Math.min(r, inLen / 2, outLen / 2)
+
+    const p1x = curr[0] + (dxIn / inLen) * rr
+    const p1y = curr[1] + (dyIn / inLen) * rr
+    const p2x = curr[0] + (dxOut / outLen) * rr
+    const p2y = curr[1] + (dyOut / outLen) * rr
+
+    parts.push(
+      i === 0
+        ? `M ${p1x.toFixed(2)} ${p1y.toFixed(2)}`
+        : `L ${p1x.toFixed(2)} ${p1y.toFixed(2)}`,
+    )
+    parts.push(
+      `Q ${curr[0].toFixed(2)} ${curr[1].toFixed(2)} ${p2x.toFixed(2)} ${p2y.toFixed(2)}`,
+    )
+  }
+  parts.push("Z")
+  return parts.join(" ")
+}
+
+// bbox の中に 1 つの図形を返す (すべて線対称 & 角丸)
 const buildShape = (
   type: ShapeType,
   bbox: BBox,
@@ -103,161 +144,118 @@ const buildShape = (
   const rand = (min: number, max: number) => min + rng() * (max - min)
   const cx = x + w / 2
   const cy = y + h / 2
-  // 柄っぽさを維持するため、回転は控えめ (±25°)
+  const size = Math.min(w, h)
+  const half = size / 2
+  const radius = size * RADIUS_RATIO
   const rotation = rand(-25, 25)
 
   const buildElement = () => {
     if (type === "triangle") {
-      const p1 = [x + rand(0, w * 0.25), y + h]
-      const p2 = [x + w - rand(0, w * 0.25), y + h]
-      const p3 = [x + rand(0.3, 0.7) * w, y + rand(0, w * 0.15)]
+      // 正三角形 (equilateral): 外接円半径 = half、頂点は上向き
+      const angles = [
+        -Math.PI / 2,
+        -Math.PI / 2 + (2 * Math.PI) / 3,
+        -Math.PI / 2 - (2 * Math.PI) / 3,
+      ]
+      const pts: [number, number][] = angles.map(
+        (a) =>
+          [cx + half * Math.cos(a), cy + half * Math.sin(a)] as [
+            number,
+            number,
+          ],
+      )
       return {
-        type: "polygon",
-        props: {
-          points: [p1, p2, p3].map(([px, py]) => `${px},${py}`).join(" "),
-          fill: color,
-        },
+        type: "path",
+        props: { d: roundedPolygonPath(pts, radius), fill: color },
       }
     }
 
     if (type === "ellipse") {
+      // 円 (両軸で線対称、無限軸)
       return {
-        type: "ellipse",
-        props: {
-          cx,
-          cy,
-          rx: (w / 2) * rand(0.75, 1),
-          ry: (h / 2) * rand(0.75, 1),
-          fill: color,
-        },
+        type: "circle",
+        props: { cx, cy, r: half, fill: color },
       }
     }
 
     if (type === "rectangle") {
-      const rectW = w * rand(0.55, 0.95)
-      const rectH = h * rand(0.55, 0.95)
+      // 正方形または長方形 (2 軸線対称) を角丸 rect で
       return {
         type: "rect",
         props: {
-          x: x + (w - rectW) / 2,
-          y: y + (h - rectH) / 2,
-          width: rectW,
-          height: rectH,
-          rx: rng() < 0.4 ? rand(10, 24) : 0,
+          x,
+          y,
+          width: w,
+          height: h,
+          rx: radius,
           fill: color,
         },
       }
     }
 
-    // geometric: 円環 / 十字 / 菱形 / X のいずれか
+    // geometric: ring / plus / diamond / X (X は plus を 45°回転)
     const variant = Math.floor(rng() * 4)
-    const r = Math.min(w, h) / 2
 
     if (variant === 0) {
-      // ring (輪郭のみの円)
+      // ring (輪郭円)
+      const strokeW = size * 0.15
       return {
         type: "circle",
         props: {
           cx,
           cy,
-          r: r * 0.85,
+          r: half - strokeW / 2,
           fill: "transparent",
           stroke: color,
-          strokeWidth: rand(12, 18),
+          strokeWidth: strokeW,
         },
       }
     }
 
-    if (variant === 1) {
-      // plus (+)
-      const armLong = r * 1.7
-      const armShort = r * 0.55
+    if (variant === 1 || variant === 3) {
+      // plus (+) と X は同じ形。X は 45° 回した plus とする
+      const armLong = size * 0.9
+      const armShort = size * 0.34
+      const L = armLong / 2
+      const S = armShort / 2
+      const pts: [number, number][] = [
+        [cx - S, cy - L],
+        [cx + S, cy - L],
+        [cx + S, cy - S],
+        [cx + L, cy - S],
+        [cx + L, cy + S],
+        [cx + S, cy + S],
+        [cx + S, cy + L],
+        [cx - S, cy + L],
+        [cx - S, cy + S],
+        [cx - L, cy + S],
+        [cx - L, cy - S],
+        [cx - S, cy - S],
+      ]
+      const extraRotate = variant === 3 ? 45 : 0
+      // 角丸半径は他図形と揃えるが、細腕の凹角では armShort/2 で制限される
+      const path = roundedPolygonPath(pts, radius)
+      const elem = { type: "path", props: { d: path, fill: color } }
+      if (extraRotate === 0) return elem
       return {
         type: "g",
         props: {
-          children: [
-            {
-              type: "rect",
-              props: {
-                x: cx - armLong / 2,
-                y: cy - armShort / 2,
-                width: armLong,
-                height: armShort,
-                fill: color,
-              },
-            },
-            {
-              type: "rect",
-              props: {
-                x: cx - armShort / 2,
-                y: cy - armLong / 2,
-                width: armShort,
-                height: armLong,
-                fill: color,
-              },
-            },
-          ],
+          transform: `rotate(${extraRotate} ${cx.toFixed(2)} ${cy.toFixed(2)})`,
+          children: elem,
         },
       }
     }
 
-    if (variant === 2) {
-      // diamond (菱形)
-      const rx = r * 0.9
-      const ry = r * 0.75
-      const pts = [
-        [cx, cy - ry],
-        [cx + rx, cy],
-        [cx, cy + ry],
-        [cx - rx, cy],
-      ]
-      return {
-        type: "polygon",
-        props: {
-          points: pts.map(([px, py]) => `${px},${py}`).join(" "),
-          fill: color,
-        },
-      }
-    }
-
-    // variant 3: X 型
-    const thick = r * 0.35
-    const long = r * 1.6
-    const s = Math.SQRT1_2
-    const arm = long / 2
-    const t = thick / 2
-    const bar1 = [
-      [cx - arm * s - t * s, cy - arm * s + t * s],
-      [cx - arm * s + t * s, cy - arm * s - t * s],
-      [cx + arm * s + t * s, cy + arm * s - t * s],
-      [cx + arm * s - t * s, cy + arm * s + t * s],
-    ]
-    const bar2 = [
-      [cx + arm * s - t * s, cy - arm * s - t * s],
-      [cx + arm * s + t * s, cy - arm * s + t * s],
-      [cx - arm * s + t * s, cy + arm * s + t * s],
-      [cx - arm * s - t * s, cy + arm * s - t * s],
+    // variant === 2: diamond (菱形: 頂点を上下左右)
+    const pts: [number, number][] = [
+      [cx, cy - half],
+      [cx + half, cy],
+      [cx, cy + half],
+      [cx - half, cy],
     ]
     return {
-      type: "g",
-      props: {
-        children: [
-          {
-            type: "polygon",
-            props: {
-              points: bar1.map(([px, py]) => `${px},${py}`).join(" "),
-              fill: color,
-            },
-          },
-          {
-            type: "polygon",
-            props: {
-              points: bar2.map(([px, py]) => `${px},${py}`).join(" "),
-              fill: color,
-            },
-          },
-        ],
-      },
+      type: "path",
+      props: { d: roundedPolygonPath(pts, radius), fill: color },
     }
   }
 


### PR DESCRIPTION
## 概要

Preview URL や Staging URL を OGP バリデータ (Twitter Card Validator / Facebook Sharing Debugger など) に投げても画像が表示されない問題を修正します。

これまで `og:image` / `og:url` は `https://blog.sh1ma.dev/og/{slug}.png` 固定で埋め込まれており、preview URL の HTML にも本番 URL のメタが入っていました。バリデータは preview URL の HTML から `og:image` を読み、`blog.sh1ma.dev/og/{slug}.png` を fetch → 本番はまだ旧 Next.js 版なので **404** → バリデータが「画像なし」と判定していました。

## 変更内容

- `scripts/build-ogp.ts` / `scripts/build-feed.ts` で `SITE_URL` 環境変数を優先するようにする (default は `https://blog.sh1ma.dev`)
- `.github/workflows/preview-deploy.yaml`:
  - PR 番号から preview URL を先に算出し、Build ステップの env に `SITE_URL` を注入
  - `og:image` / `og:url` / `<link rel="canonical">` 相当が preview URL 上の自身を指す
- `.github/workflows/staging-deploy.yaml`: 同様に staging URL を注入
- `production-deploy.yaml` は default のまま (常に `blog.sh1ma.dev`)

## 関連Issue

なし (#150 のフォロー)

## テスト項目

- [x] `SITE_URL=https://pr-150-blog.sh1ma.workers.dev pnpm build:ogp` でローカル生成した `dist/articles/*/index.html` の `og:image` が preview URL を指すことを確認
- [ ] Preview デプロイ後に `curl -sL <preview>/articles/{slug}/ | grep og:image` で自身の URL を指すことを確認
- [ ] Twitter Card Validator / opengraph.xyz などで preview URL を投げて OGP 画像が表示されることを確認

## VRT設定

- [ ] スナップショットを更新する

UI 変更なし

## スクリーンショット（任意）

なし

## 備考

- 本 PR は #150 マージ後のフォローアップ
- 本番 (`blog.sh1ma.dev`) は `deploy` ブランチ経由でプロモートされるまで旧 Next.js 版のまま。次のプロモートで解決される