### PR TITLE
fix(preview-cleanup): pagination と workflow_dispatch のコメント更新失敗を修正

### DIFF
--- a/.github/workflows/preview-cleanup.yaml
+++ b/.github/workflows/preview-cleanup.yaml
@@ -33,15 +33,42 @@ jobs:
           ALIAS="pr-${PR_NUM}"
           API="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}"
 
-          # pr-{N} alias が振られている version を全て取得。
-          # alias は version の annotation なので、対象 version を消せば alias も消える。
-          # Cloudflare 側の 1 alias = 1 version (最新のみ有効) だが、alias 履歴として
-          # 過去に pr-{N} が振られていた version も含めて掃除しておく。
-          VERSIONS=$(curl -fsS \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            "${API}/workers/scripts/${WORKER_NAME}/versions?per_page=100" \
-            | jq -r --arg alias "${ALIAS}" \
-                '.result.items[] | select(.annotations["workers/alias"] == $alias) | .id')
+          # 全 version から pr-{N} alias が付いているものを収集。
+          # 全ページ舐めるのは重いので、対象 alias が見つからないページが続いたら早期打ち切り。
+          # alias は最新の version が保持する annotation なので、通常は最初の数ページで見つかる。
+          # ただし過去に何度も upload された PR は複数ページに散っている可能性あり。
+          VERSIONS=""
+          PAGE=1
+          EMPTY_PAGES=0
+          while [ "${PAGE}" -le 20 ]; do
+            PAGE_JSON=$(curl -fsS \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              "${API}/workers/scripts/${WORKER_NAME}/versions?per_page=100&page=${PAGE}")
+            COUNT_ON_PAGE=$(echo "${PAGE_JSON}" | jq -r '.result.items | length')
+            if [ "${COUNT_ON_PAGE}" = "0" ]; then
+              break
+            fi
+            MATCH_IDS=$(echo "${PAGE_JSON}" | jq -r --arg alias "${ALIAS}" \
+              '.result.items[] | select(.annotations["workers/alias"] == $alias) | .id')
+            if [ -n "${MATCH_IDS}" ]; then
+              VERSIONS="${VERSIONS}${MATCH_IDS}"$'\n'
+              EMPTY_PAGES=0
+            else
+              EMPTY_PAGES=$((EMPTY_PAGES + 1))
+              # 3 ページ連続でヒットしなくなったら打ち切り
+              if [ "${EMPTY_PAGES}" -ge 3 ] && [ -n "${VERSIONS}" ]; then
+                break
+              fi
+              # まだ 1 件もヒットしていない場合は 5 ページまで探す
+              if [ "${EMPTY_PAGES}" -ge 5 ] && [ -z "${VERSIONS}" ]; then
+                break
+              fi
+            fi
+            PAGE=$((PAGE + 1))
+          done
+
+          # 重複除去 + 空行削除
+          VERSIONS=$(echo "${VERSIONS}" | awk 'NF' | sort -u)
 
           if [ -z "${VERSIONS}" ]; then
             echo "No preview version found for alias ${ALIAS}. Nothing to delete."
@@ -72,9 +99,15 @@ jobs:
         env:
           CLEANUP_OUTCOME: ${{ steps.cleanup.outcome }}
           DELETED_COUNT: ${{ steps.cleanup.outputs.deleted }}
+          PR_NUM: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:
           script: |
-            const prNum = context.issue.number;
+            const prNum = Number(process.env.PR_NUM);
+            if (!Number.isInteger(prNum) || prNum <= 0) {
+              core.info(`No valid PR number (got ${process.env.PR_NUM}); skipping comment update.`);
+              return;
+            }
+
             const outcome = process.env.CLEANUP_OUTCOME;
             const deleted = process.env.DELETED_COUNT;
 


### PR DESCRIPTION
## 概要

#152 で追加した `preview-cleanup.yaml` を workflow_dispatch で PR #150 に対して実運用検証したところ、以下 2 点の不具合が判明したので修正する。

- `per_page=100` の 1 ページのみで検索していたため、version 総数が 100 を超える環境 (実測 262 件) では古い PR alias を発見できず「見つかりませんでした」で終わっていた。実際 pr-150 の version #256 は 100 位以降だったため掃除されなかった。
- `workflow_dispatch` 起動時は `context.issue.number` が空 (`""`) になり、PR コメント更新ステップが `GET /repos/.../issues//comments` で 404 になっていた。

## 変更内容

- `Delete preview alias versions` ステップ:
  - `per_page=100&page=N` で最大 20 ページまで走査。3 ページ連続でヒットしなくなった時点で早期打ち切り (通常 alias は最新の version にしか付かないため大抵 1〜数ページで見つかる)。
  - まだ 1 件もヒットしていない場合は 5 ページまで探索する。
  - 収集した version_id は `sort -u` で重複除去。
- `Update PR comment` ステップ:
  - `PR_NUM` 環境変数を明示的に受け取り、無効な値なら `core.info` で警告して早期 return。
  - workflow_dispatch でも `inputs.pr_number` を経由してコメント更新が走るようにした。

## 関連 Issue / PR

- #152 のフォローアップ

## テスト項目

- [ ] `workflow_dispatch` で `pr_number=150` を指定して実行 → version #256 が削除され、`https://pr-150-blog.<subdomain>.workers.dev` が 404 になる
- [ ] 同じ実行で PR #150 の Preview Deploy コメントが「削除しました (1 件)」に更新される
- [ ] 次に PR を通常クローズしたときに、これまで通り自動 cleanup が動く

## VRT 設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

UI 変更なし。

## スクリーンショット（任意）

なし。

## 備考

- 20 ページ (最大 2000 version) を上限にしているが、Cloudflare 上限が 1000 なので余裕あり。
- 早期打ち切りヒューリスティックは alias が「基本的に最新の 1 version にしか付いていない」前提。preview-alias を毎回張り替える現運用と一致する。