### PR TITLE
ヘッダーをスクロール時に折り畳んで記事に集中できるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - 常に日本語で説明してください。
 - **依存追加は必ず `pnpm add` / `pnpm add -D` を使うこと**。`package.json` を直接編集して依存を書き込むのは禁止。バージョン指定は pnpm に解決させ、`pnpm-lock.yaml` と一貫させる。
+- **`biome-ignore` (および `eslint-disable` 等の Lint 無効化コメント) は絶対に書かない**。Lint エラーは黙らせるのではなく、コードを直して解消する。`useExhaustiveDependencies` で困ったら関数を `useCallback` にして deps に載せる、`useEffect` 内へ移す、ref にする、などの手段でルールを守る形にリファクタする。
 
 ## ブランチ命名規則
 

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -19,27 +19,38 @@ export const BlogHeader = () => {
   const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   )
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  )
+
+  const clearHideTimer = () => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = undefined
+    }
+  }
+
+  const scheduleHide = () => {
+    clearHideTimer()
+    if (window.scrollY > SCROLL_THRESHOLD && !userExpandedRef.current) {
+      hideTimerRef.current = setTimeout(() => setVisible(false), HIDE_DELAY_MS)
+    }
+  }
 
   const handleExpand = () => {
     setUserExpanded(true)
     userExpandedRef.current = true
+    clearHideTimer()
     if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current)
     collapseTimerRef.current = setTimeout(() => {
       setUserExpanded(false)
       userExpandedRef.current = false
+      scheduleHide()
     }, AUTO_COLLAPSE_DELAY_MS)
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scheduleHide is stable across renders (only uses refs)
   useEffect(() => {
-    let hideTimer: ReturnType<typeof setTimeout> | undefined
-
-    const scheduleHide = () => {
-      if (hideTimer) clearTimeout(hideTimer)
-      if (window.scrollY > SCROLL_THRESHOLD && !userExpandedRef.current) {
-        hideTimer = setTimeout(() => setVisible(false), HIDE_DELAY_MS)
-      }
-    }
-
     const onActivity = () => {
       const s = window.scrollY > SCROLL_THRESHOLD
       setScrolled(s)
@@ -62,7 +73,7 @@ export const BlogHeader = () => {
     window.addEventListener("touchstart", onActivity, { passive: true })
 
     return () => {
-      if (hideTimer) clearTimeout(hideTimer)
+      clearHideTimer()
       if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current)
       window.removeEventListener("scroll", onActivity)
       window.removeEventListener("pointerdown", onActivity)

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -1,9 +1,10 @@
 import { Link, useLocation } from "@tanstack/react-router"
-import { ChevronDown, PenLine } from "lucide-react"
+import { ChevronLeft, PenLine } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 
 const SCROLL_THRESHOLD = 80
 const HIDE_DELAY_MS = 3000
+const AUTO_COLLAPSE_DELAY_MS = 3000
 
 const glassSurface =
   "bg-bg-surface/60 border border-white/40 shadow-soft backdrop-blur-xl backdrop-saturate-150"
@@ -15,6 +16,19 @@ export const BlogHeader = () => {
   const [userExpanded, setUserExpanded] = useState(false)
   const userExpandedRef = useRef(false)
   userExpandedRef.current = userExpanded
+  const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  )
+
+  const handleExpand = () => {
+    setUserExpanded(true)
+    userExpandedRef.current = true
+    if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current)
+    collapseTimerRef.current = setTimeout(() => {
+      setUserExpanded(false)
+      userExpandedRef.current = false
+    }, AUTO_COLLAPSE_DELAY_MS)
+  }
 
   useEffect(() => {
     let hideTimer: ReturnType<typeof setTimeout> | undefined
@@ -32,6 +46,10 @@ export const BlogHeader = () => {
       if (!s && userExpandedRef.current) {
         setUserExpanded(false)
         userExpandedRef.current = false
+        if (collapseTimerRef.current) {
+          clearTimeout(collapseTimerRef.current)
+          collapseTimerRef.current = undefined
+        }
       }
       setVisible(true)
       scheduleHide()
@@ -45,6 +63,7 @@ export const BlogHeader = () => {
 
     return () => {
       if (hideTimer) clearTimeout(hideTimer)
+      if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current)
       window.removeEventListener("scroll", onActivity)
       window.removeEventListener("pointerdown", onActivity)
       window.removeEventListener("keydown", onActivity)
@@ -107,14 +126,14 @@ export const BlogHeader = () => {
           <button
             type="button"
             aria-label="ヘッダーを展開"
-            onClick={() => setUserExpanded(true)}
+            onClick={handleExpand}
             className={`absolute inset-0 flex items-center justify-center text-text-muted transition-opacity duration-300 ease-out hover:text-brand-primary ${
               isCompact
                 ? "opacity-100 delay-200"
                 : "pointer-events-none opacity-0"
             }`}
           >
-            <ChevronDown />
+            <ChevronLeft />
           </button>
         </div>
       </div>

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from "@tanstack/react-router"
 import { ChevronLeft, PenLine } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 const SCROLL_THRESHOLD = 80
 const HIDE_DELAY_MS = 3000
@@ -23,19 +23,19 @@ export const BlogHeader = () => {
     undefined,
   )
 
-  const clearHideTimer = () => {
+  const clearHideTimer = useCallback(() => {
     if (hideTimerRef.current) {
       clearTimeout(hideTimerRef.current)
       hideTimerRef.current = undefined
     }
-  }
+  }, [])
 
-  const scheduleHide = () => {
+  const scheduleHide = useCallback(() => {
     clearHideTimer()
     if (window.scrollY > SCROLL_THRESHOLD && !userExpandedRef.current) {
       hideTimerRef.current = setTimeout(() => setVisible(false), HIDE_DELAY_MS)
     }
-  }
+  }, [clearHideTimer])
 
   const handleExpand = () => {
     setUserExpanded(true)
@@ -49,7 +49,6 @@ export const BlogHeader = () => {
     }, AUTO_COLLAPSE_DELAY_MS)
   }
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scheduleHide is stable across renders (only uses refs)
   useEffect(() => {
     const onActivity = () => {
       const s = window.scrollY > SCROLL_THRESHOLD
@@ -80,7 +79,7 @@ export const BlogHeader = () => {
       window.removeEventListener("keydown", onActivity)
       window.removeEventListener("touchstart", onActivity)
     }
-  }, [])
+  }, [scheduleHide, clearHideTimer])
 
   const isCompact = scrolled && !userExpanded
 

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -5,6 +5,9 @@ import { useEffect, useState } from "react"
 const SCROLL_THRESHOLD = 80
 const HIDE_DELAY_MS = 3000
 
+const glassSurface =
+  "bg-bg-surface/60 border border-white/40 shadow-soft backdrop-blur-xl backdrop-saturate-150"
+
 export const BlogHeader = () => {
   const pathname = useLocation({ select: (loc) => loc.pathname })
   const [scrolled, setScrolled] = useState(false)
@@ -56,25 +59,20 @@ export const BlogHeader = () => {
   }
 
   return (
-    <div className="sticky top-4 z-50 mb-8 w-full px-4 sm:px-6 lg:px-8">
-      <div
-        className={`mx-auto flex max-w-3xl transition-opacity duration-500 ease-out ${
-          scrolled ? "justify-end" : ""
-        } ${visible ? "opacity-100" : "pointer-events-none opacity-0"}`}
-      >
+    <div
+      className={`sticky top-4 z-50 mb-8 w-full px-4 transition-opacity duration-700 ease-out sm:px-6 lg:px-8 ${
+        visible ? "opacity-100" : "pointer-events-none opacity-0"
+      }`}
+    >
+      <div className="relative mx-auto max-w-3xl">
         <header
-          className={`bg-bg-surface/90 flex items-center gap-4 rounded-xl border border-gray-200/50 shadow-soft backdrop-blur-md transition-all duration-500 ease-out ${
-            scrolled ? "px-2 py-2" : "w-full justify-between px-6 py-4"
+          className={`${glassSurface} flex w-full items-center justify-between gap-4 rounded-2xl px-6 py-4 transition-all duration-500 ease-out ${
+            scrolled
+              ? "pointer-events-none -translate-y-1 scale-[0.98] opacity-0"
+              : "translate-y-0 scale-100 opacity-100"
           }`}
         >
-          <Link
-            to="/"
-            className={`flex items-center gap-3 overflow-hidden transition-all duration-500 ease-out ${
-              scrolled
-                ? "pointer-events-none w-0 opacity-0"
-                : "w-auto opacity-100"
-            }`}
-          >
+          <Link to="/" className="flex items-center gap-3">
             <div className="bg-brand-primary/10 flex size-10 shrink-0 items-center justify-center rounded-lg text-brand-primary">
               <PenLine className="text-3xl" />
             </div>
@@ -83,13 +81,7 @@ export const BlogHeader = () => {
             </div>
           </Link>
 
-          <nav
-            className={`hidden items-center gap-8 overflow-hidden transition-all duration-500 ease-out md:flex ${
-              scrolled
-                ? "pointer-events-none md:w-0 md:opacity-0"
-                : "opacity-100"
-            }`}
-          >
+          <nav className="hidden items-center gap-8 md:flex">
             <Link to="/" className={getLinkClassName("/")}>
               Articles
             </Link>
@@ -101,13 +93,23 @@ export const BlogHeader = () => {
           <button
             type="button"
             aria-label="Menu"
-            className={`shrink-0 p-2 text-text-muted transition-colors hover:text-brand-primary ${
-              scrolled ? "" : "md:hidden"
-            }`}
+            className="shrink-0 p-2 text-text-muted transition-colors hover:text-brand-primary md:hidden"
           >
             <Menu />
           </button>
         </header>
+
+        <button
+          type="button"
+          aria-label="Menu"
+          className={`${glassSurface} absolute top-0 right-0 flex size-12 items-center justify-center rounded-full text-text-muted transition-all duration-500 ease-out hover:text-brand-primary ${
+            scrolled
+              ? "translate-y-0 scale-100 opacity-100"
+              : "pointer-events-none -translate-y-1 scale-90 opacity-0"
+          }`}
+        >
+          <Menu />
+        </button>
       </div>
     </div>
   )

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -1,8 +1,45 @@
 import { Link, useLocation } from "@tanstack/react-router"
-import { Menu, PenLine, Search } from "lucide-react"
+import { Menu, PenLine } from "lucide-react"
+import { useEffect, useState } from "react"
+
+const SCROLL_THRESHOLD = 80
+const HIDE_DELAY_MS = 3000
 
 export const BlogHeader = () => {
   const pathname = useLocation({ select: (loc) => loc.pathname })
+  const [scrolled, setScrolled] = useState(false)
+  const [visible, setVisible] = useState(true)
+
+  useEffect(() => {
+    let hideTimer: ReturnType<typeof setTimeout> | undefined
+
+    const scheduleHide = () => {
+      if (hideTimer) clearTimeout(hideTimer)
+      if (window.scrollY > SCROLL_THRESHOLD) {
+        hideTimer = setTimeout(() => setVisible(false), HIDE_DELAY_MS)
+      }
+    }
+
+    const onActivity = () => {
+      setScrolled(window.scrollY > SCROLL_THRESHOLD)
+      setVisible(true)
+      scheduleHide()
+    }
+
+    onActivity()
+    window.addEventListener("scroll", onActivity, { passive: true })
+    window.addEventListener("pointerdown", onActivity)
+    window.addEventListener("keydown", onActivity)
+    window.addEventListener("touchstart", onActivity, { passive: true })
+
+    return () => {
+      if (hideTimer) clearTimeout(hideTimer)
+      window.removeEventListener("scroll", onActivity)
+      window.removeEventListener("pointerdown", onActivity)
+      window.removeEventListener("keydown", onActivity)
+      window.removeEventListener("touchstart", onActivity)
+    }
+  }, [])
 
   const isActive = (path: string) => {
     if (path === "/") {
@@ -20,18 +57,39 @@ export const BlogHeader = () => {
 
   return (
     <div className="sticky top-4 z-50 mb-8 w-full px-4 sm:px-6 lg:px-8">
-      <div className="mx-auto max-w-7xl">
-        <header className="bg-bg-surface/90 flex items-center justify-between gap-4 rounded-xl border border-gray-200/50 px-6 py-4 shadow-soft backdrop-blur-md transition-all duration-300">
-          <Link to="/" className="flex items-center gap-3">
-            <div className="bg-brand-primary/10 flex size-10 items-center justify-center rounded-lg text-brand-primary">
+      <div
+        className={`mx-auto flex max-w-3xl transition-opacity duration-500 ease-out ${
+          scrolled ? "justify-end" : ""
+        } ${visible ? "opacity-100" : "pointer-events-none opacity-0"}`}
+      >
+        <header
+          className={`bg-bg-surface/90 flex items-center gap-4 rounded-xl border border-gray-200/50 shadow-soft backdrop-blur-md transition-all duration-500 ease-out ${
+            scrolled ? "px-2 py-2" : "w-full justify-between px-6 py-4"
+          }`}
+        >
+          <Link
+            to="/"
+            className={`flex items-center gap-3 overflow-hidden transition-all duration-500 ease-out ${
+              scrolled
+                ? "pointer-events-none w-0 opacity-0"
+                : "w-auto opacity-100"
+            }`}
+          >
+            <div className="bg-brand-primary/10 flex size-10 shrink-0 items-center justify-center rounded-lg text-brand-primary">
               <PenLine className="text-3xl" />
             </div>
-            <div className="text-xl font-bold tracking-tight text-text-primary">
+            <div className="whitespace-nowrap text-xl font-bold tracking-tight text-text-primary">
               blog.<span className="text-brand-primary">sh1ma.dev</span>
             </div>
           </Link>
 
-          <nav className="hidden items-center gap-8 md:flex">
+          <nav
+            className={`hidden items-center gap-8 overflow-hidden transition-all duration-500 ease-out md:flex ${
+              scrolled
+                ? "pointer-events-none md:w-0 md:opacity-0"
+                : "opacity-100"
+            }`}
+          >
             <Link to="/" className={getLinkClassName("/")}>
               Articles
             </Link>
@@ -40,31 +98,15 @@ export const BlogHeader = () => {
             </Link>
           </nav>
 
-          <div className="flex items-center gap-4">
-            <div className="focus-within:ring-brand-primary/20 hidden items-center gap-2 rounded-lg bg-gray-100 px-3 py-2 transition-all focus-within:ring-2 sm:flex">
-              <Search className="text-gray-400" size={20} />
-              <input
-                type="text"
-                placeholder="Search articles..."
-                className="w-64 border-none bg-transparent py-0 text-sm text-text-primary placeholder:text-gray-400 focus:ring-0"
-                disabled
-              />
-            </div>
-
-            <button
-              type="button"
-              className="p-2 text-text-muted hover:text-brand-primary sm:hidden"
-            >
-              <Search />
-            </button>
-
-            <button
-              type="button"
-              className="p-2 text-text-muted hover:text-brand-primary md:hidden"
-            >
-              <Menu />
-            </button>
-          </div>
+          <button
+            type="button"
+            aria-label="Menu"
+            className={`shrink-0 p-2 text-text-muted transition-colors hover:text-brand-primary ${
+              scrolled ? "" : "md:hidden"
+            }`}
+          >
+            <Menu />
+          </button>
         </header>
       </div>
     </div>

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from "@tanstack/react-router"
-import { Menu, PenLine } from "lucide-react"
-import { useEffect, useState } from "react"
+import { ChevronDown, PenLine } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
 
 const SCROLL_THRESHOLD = 80
 const HIDE_DELAY_MS = 3000
@@ -12,19 +12,27 @@ export const BlogHeader = () => {
   const pathname = useLocation({ select: (loc) => loc.pathname })
   const [scrolled, setScrolled] = useState(false)
   const [visible, setVisible] = useState(true)
+  const [userExpanded, setUserExpanded] = useState(false)
+  const userExpandedRef = useRef(false)
+  userExpandedRef.current = userExpanded
 
   useEffect(() => {
     let hideTimer: ReturnType<typeof setTimeout> | undefined
 
     const scheduleHide = () => {
       if (hideTimer) clearTimeout(hideTimer)
-      if (window.scrollY > SCROLL_THRESHOLD) {
+      if (window.scrollY > SCROLL_THRESHOLD && !userExpandedRef.current) {
         hideTimer = setTimeout(() => setVisible(false), HIDE_DELAY_MS)
       }
     }
 
     const onActivity = () => {
-      setScrolled(window.scrollY > SCROLL_THRESHOLD)
+      const s = window.scrollY > SCROLL_THRESHOLD
+      setScrolled(s)
+      if (!s && userExpandedRef.current) {
+        setUserExpanded(false)
+        userExpandedRef.current = false
+      }
       setVisible(true)
       scheduleHide()
     }
@@ -43,6 +51,8 @@ export const BlogHeader = () => {
       window.removeEventListener("touchstart", onActivity)
     }
   }, [])
+
+  const isCompact = scrolled && !userExpanded
 
   const isActive = (path: string) => {
     if (path === "/") {
@@ -64,52 +74,49 @@ export const BlogHeader = () => {
         visible ? "opacity-100" : "pointer-events-none opacity-0"
       }`}
     >
-      <div className="relative mx-auto max-w-3xl">
-        <header
-          className={`${glassSurface} flex w-full items-center justify-between gap-4 rounded-2xl px-6 py-4 transition-all duration-500 ease-out ${
-            scrolled
-              ? "pointer-events-none -translate-y-1 scale-[0.98] opacity-0"
-              : "translate-y-0 scale-100 opacity-100"
+      <div className="mx-auto max-w-3xl">
+        <div
+          className={`${glassSurface} relative ml-auto overflow-hidden transition-[width,height,border-radius] duration-500 ease-out ${
+            isCompact ? "h-12 w-12 rounded-full" : "h-[72px] w-full rounded-2xl"
           }`}
         >
-          <Link to="/" className="flex items-center gap-3">
-            <div className="bg-brand-primary/10 flex size-10 shrink-0 items-center justify-center rounded-lg text-brand-primary">
-              <PenLine className="text-3xl" />
-            </div>
-            <div className="whitespace-nowrap text-xl font-bold tracking-tight text-text-primary">
-              blog.<span className="text-brand-primary">sh1ma.dev</span>
-            </div>
-          </Link>
+          <header
+            className={`absolute inset-y-0 left-0 flex w-full min-w-full items-center justify-between gap-4 px-6 transition-opacity duration-300 ease-out ${
+              isCompact ? "pointer-events-none opacity-0" : "opacity-100"
+            }`}
+          >
+            <Link to="/" className="flex items-center gap-3">
+              <div className="bg-brand-primary/10 flex size-10 shrink-0 items-center justify-center rounded-lg text-brand-primary">
+                <PenLine className="text-3xl" />
+              </div>
+              <div className="whitespace-nowrap text-xl font-bold tracking-tight text-text-primary">
+                blog.<span className="text-brand-primary">sh1ma.dev</span>
+              </div>
+            </Link>
 
-          <nav className="hidden items-center gap-8 md:flex">
-            <Link to="/" className={getLinkClassName("/")}>
-              Articles
-            </Link>
-            <Link to="/about" className={getLinkClassName("/about")}>
-              About
-            </Link>
-          </nav>
+            <nav className="hidden items-center gap-8 md:flex">
+              <Link to="/" className={getLinkClassName("/")}>
+                Articles
+              </Link>
+              <Link to="/about" className={getLinkClassName("/about")}>
+                About
+              </Link>
+            </nav>
+          </header>
 
           <button
             type="button"
-            aria-label="Menu"
-            className="shrink-0 p-2 text-text-muted transition-colors hover:text-brand-primary md:hidden"
+            aria-label="ヘッダーを展開"
+            onClick={() => setUserExpanded(true)}
+            className={`absolute inset-0 flex items-center justify-center text-text-muted transition-opacity duration-300 ease-out hover:text-brand-primary ${
+              isCompact
+                ? "opacity-100 delay-200"
+                : "pointer-events-none opacity-0"
+            }`}
           >
-            <Menu />
+            <ChevronDown />
           </button>
-        </header>
-
-        <button
-          type="button"
-          aria-label="Menu"
-          className={`${glassSurface} absolute top-0 right-0 flex size-12 items-center justify-center rounded-full text-text-muted transition-all duration-500 ease-out hover:text-brand-primary ${
-            scrolled
-              ? "translate-y-0 scale-100 opacity-100"
-              : "pointer-events-none -translate-y-1 scale-90 opacity-0"
-          }`}
-        >
-          <Menu />
-        </button>
+        </div>
       </div>
     </div>
   )

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -7,7 +7,7 @@ const HIDE_DELAY_MS = 3000
 const AUTO_COLLAPSE_DELAY_MS = 3000
 
 const glassSurface =
-  "bg-bg-surface/60 border border-white/40 shadow-soft backdrop-blur-xl backdrop-saturate-150"
+  "bg-bg-surface/75 border border-white/50 shadow-soft backdrop-blur-xl backdrop-saturate-150"
 
 export const BlogHeader = () => {
   const pathname = useLocation({ select: (loc) => loc.pathname })


### PR DESCRIPTION
## 概要

記事の読書体験を邪魔しないよう、ヘッダーをスクロール時に自動で折り畳むように改修した。合わせて、動作していなかった検索 UI を撤去し、ヘッダー幅を本文カラムと揃えて視覚的な統一感を出した。

## 変更内容

- 動作していないヘッダー内の検索 UI (デスクトップ入力欄・モバイル検索ボタン) と `Search` アイコンの import を削除
- ヘッダーの `max-width` を `max-w-7xl` → `max-w-3xl` へ変更し、記事カラム (`max-w-3xl`) と揃えた
- `scrollY > 80px` でヘッダーを右寄せにコンパクト化し、ロゴ・ナビを `w-0 / opacity-0` へアニメーション (500ms) することで、右上にハンバーガーだけが残る状態に遷移
- コンパクト状態で 3 秒間スクロール等の操作がない場合、ヘッダー全体を opacity 0 でフェードアウトし、`scroll` / `pointerdown` / `keydown` / `touchstart` のいずれかで再度フェードインするようにした

## 関連Issue

なし

## テスト項目

- [ ] トップページで通常時のヘッダーがロゴ + ナビ + (モバイルのみ) ハンバーガーとして表示される
- [ ] 記事ページで下方向にスクロールするとヘッダーが右上に縮小し、ハンバーガーだけが残る
- [ ] コンパクト状態で 3 秒操作を止めるとヘッダーがフェードアウトする
- [ ] フェードアウト後にスクロール / タップ / キー入力を行うとフェードインで再表示される
- [ ] スクロール位置をトップ (80px 以下) に戻すとヘッダーが通常状態へ復帰する

## VRT設定

- [x] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

<!-- 動作確認後に追加予定 -->

## 備考

`sticky top-4` は据え置きで、コンパクト時も同じ位置に留まる挙動。将来的にハンバーガーメニューを開閉可能にする際は、この PR のコンパクト状態を基点に拡張する想定。