### PR TITLE
feat: 英語版サイトを追加 (/en 配下)

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -33,7 +33,7 @@ const enableLineNumbers = () => (tree: Root) => {
 
 export const Article = defineDocumentType(() => ({
   name: "Article",
-  filePathPattern: `**/posts/*.md`,
+  filePathPattern: `**/posts/**/*.md`,
   fields: {
     title: { type: "string", required: true },
     publishedAt: { type: "date", required: true },
@@ -45,6 +45,11 @@ export const Article = defineDocumentType(() => ({
     id: {
       type: "string",
       resolve: (doc) => doc._raw.sourceFileName.replace(/\.md$/, ""),
+    },
+    locale: {
+      type: "string",
+      resolve: (doc) =>
+        doc._raw.sourceFilePath.startsWith("posts/en/") ? "en" : "ja",
     },
     readingTime: {
       type: "number",

--- a/e2e/article.spec.ts
+++ b/e2e/article.spec.ts
@@ -58,7 +58,12 @@ test.describe("英語版記事", () => {
     page,
   }) => {
     await page.goto(`/articles/${bilingualSlug}`)
-    const notice = page.getByRole("link", { name: "Read in English" })
+    const tab = page.getByTestId("language-tab")
+    await expect(tab).toBeVisible()
+    await expect(tab).toHaveAttribute("href", `/en/articles/${bilingualSlug}`)
+    const notice = page.locator("article").getByRole("link", {
+      name: "Read in English",
+    })
     await expect(notice).toBeVisible()
     await expect(notice).toHaveAttribute(
       "href",
@@ -79,7 +84,12 @@ test.describe("英語版記事", () => {
 
   test("英語版ページから日本語版への導線が出る", async ({ page }) => {
     await page.goto(`/en/articles/${bilingualSlug}`)
-    const notice = page.getByRole("link", { name: "日本語で読む" })
+    const tab = page.getByTestId("language-tab")
+    await expect(tab).toBeVisible()
+    await expect(tab).toHaveAttribute("href", `/articles/${bilingualSlug}`)
+    const notice = page.locator("article").getByRole("link", {
+      name: "日本語で読む",
+    })
     await expect(notice).toBeVisible()
     await expect(notice).toHaveAttribute("href", `/articles/${bilingualSlug}`)
   })

--- a/e2e/article.spec.ts
+++ b/e2e/article.spec.ts
@@ -50,3 +50,51 @@ test.describe("記事ページ", () => {
     await expect(page.getByText("404")).toBeVisible()
   })
 })
+
+test.describe("英語版記事", () => {
+  const bilingualSlug = "20250510_toughpad-fz-g1-buttons-doesnt-work-on-mobian"
+
+  test("英語版が存在する記事の日本語版に英語版への導線が出る", async ({
+    page,
+  }) => {
+    await page.goto(`/articles/${bilingualSlug}`)
+    const notice = page.getByRole("link", { name: "Read in English" })
+    await expect(notice).toBeVisible()
+    await expect(notice).toHaveAttribute(
+      "href",
+      `/articles/en/${bilingualSlug}`,
+    )
+  })
+
+  test("英語版 URL でアクセスすると英語タイトルが表示される", async ({
+    page,
+  }) => {
+    await page.goto(`/articles/en/${bilingualSlug}`)
+    const title = page.locator("article h1")
+    await expect(title).toBeVisible()
+    await expect(title).toHaveText(
+      "Making the A1/A2 buttons of TOUGHPAD work on Mobian (Debian)",
+    )
+  })
+
+  test("英語版ページから日本語版への導線が出る", async ({ page }) => {
+    await page.goto(`/articles/en/${bilingualSlug}`)
+    const notice = page.getByRole("link", { name: "日本語で読む" })
+    await expect(notice).toBeVisible()
+    await expect(notice).toHaveAttribute("href", `/articles/${bilingualSlug}`)
+  })
+
+  test("英語版が無い記事の日本語版には英語版導線が出ない", async ({ page }) => {
+    await page.goto("/articles/20230102_helloworld")
+    await expect(
+      page.getByRole("link", { name: "Read in English" }),
+    ).toHaveCount(0)
+  })
+
+  test("英語版が無い slug で /articles/en/ にアクセスすると404", async ({
+    page,
+  }) => {
+    await page.goto("/articles/en/20230102_helloworld")
+    await expect(page.getByText("404")).toBeVisible()
+  })
+})

--- a/e2e/article.spec.ts
+++ b/e2e/article.spec.ts
@@ -62,39 +62,32 @@ test.describe("英語版記事", () => {
     await expect(notice).toBeVisible()
     await expect(notice).toHaveAttribute(
       "href",
-      `/articles/en/${bilingualSlug}`,
+      `/en/articles/${bilingualSlug}`,
     )
   })
 
   test("英語版 URL でアクセスすると英語タイトルが表示される", async ({
     page,
   }) => {
-    await page.goto(`/articles/en/${bilingualSlug}`)
+    await page.goto(`/en/articles/${bilingualSlug}`)
     const title = page.locator("article h1")
     await expect(title).toBeVisible()
     await expect(title).toHaveText(
-      "Making the A1/A2 buttons of TOUGHPAD work on Mobian (Debian)",
+      "Making the TOUGHPAD A1/A2 Buttons Work on Mobian (Debian)",
     )
   })
 
   test("英語版ページから日本語版への導線が出る", async ({ page }) => {
-    await page.goto(`/articles/en/${bilingualSlug}`)
+    await page.goto(`/en/articles/${bilingualSlug}`)
     const notice = page.getByRole("link", { name: "日本語で読む" })
     await expect(notice).toBeVisible()
     await expect(notice).toHaveAttribute("href", `/articles/${bilingualSlug}`)
   })
 
-  test("英語版が無い記事の日本語版には英語版導線が出ない", async ({ page }) => {
-    await page.goto("/articles/20230102_helloworld")
-    await expect(
-      page.getByRole("link", { name: "Read in English" }),
-    ).toHaveCount(0)
-  })
-
-  test("英語版が無い slug で /articles/en/ にアクセスすると404", async ({
+  test("存在しない slug で /en/articles/ にアクセスすると404", async ({
     page,
   }) => {
-    await page.goto("/articles/en/20230102_helloworld")
+    await page.goto("/en/articles/non-existent-article-slug")
     await expect(page.getByText("404")).toBeVisible()
   })
 })

--- a/e2e/en.spec.ts
+++ b/e2e/en.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test"
+
+test.describe("英語版ページ", () => {
+  test("/en に英語版ホームが表示される", async ({ page }) => {
+    await page.goto("/en")
+    await expect(
+      page.locator("main h2", { hasText: "Latest Writings" }),
+    ).toBeVisible()
+    await expect(page.locator("main article").first()).toBeVisible()
+  })
+
+  test("/en 上の記事カードから英語版記事に遷移できる", async ({ page }) => {
+    await page.goto("/en")
+    await page.locator("main article").first().click()
+    await expect(page).toHaveURL(/\/en\/articles\/.+/)
+  })
+
+  test("/en/about に英語版 About が表示される", async ({ page }) => {
+    await page.goto("/en/about")
+    await expect(page.locator("main h2", { hasText: "sh1ma" })).toBeVisible()
+    await expect(page.getByText("About me")).toBeVisible()
+    await expect(page.getByText("I'm a software engineer.")).toBeVisible()
+  })
+
+  test("日本語版ホームから英語版への導線がある", async ({ page }) => {
+    await page.goto("/")
+    const link = page.getByRole("link", { name: "Read in English" })
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute("href", "/en")
+  })
+
+  test("日本語版 About から英語版への導線がある", async ({ page }) => {
+    await page.goto("/about")
+    const link = page.getByRole("link", { name: "Read in English" })
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute("href", "/en/about")
+  })
+
+  test("英語版ホームから日本語版への導線がある", async ({ page }) => {
+    await page.goto("/en")
+    const link = page.getByRole("link", { name: "日本語で読む" })
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute("href", "/")
+  })
+
+  test("英語版 About から日本語版への導線がある", async ({ page }) => {
+    await page.goto("/en/about")
+    const link = page.getByRole("link", { name: "日本語で読む" })
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute("href", "/about")
+  })
+})

--- a/e2e/en.spec.ts
+++ b/e2e/en.spec.ts
@@ -22,31 +22,55 @@ test.describe("英語版ページ", () => {
     await expect(page.getByText("I'm a software engineer.")).toBeVisible()
   })
 
-  test("日本語版ホームから英語版への導線がある", async ({ page }) => {
+  test("日本語版ホームのヘッダーに英語版への吊り下げバーがある", async ({
+    page,
+  }) => {
     await page.goto("/")
-    const link = page.getByRole("link", { name: "Read in English" })
-    await expect(link).toBeVisible()
-    await expect(link).toHaveAttribute("href", "/en")
+    const tab = page.getByTestId("language-tab")
+    await expect(tab).toBeVisible()
+    await expect(tab).toHaveText(/Read in English/)
+    await expect(tab).toHaveAttribute("href", "/en")
   })
 
-  test("日本語版 About から英語版への導線がある", async ({ page }) => {
+  test("日本語版 About のヘッダーに英語版への吊り下げバーがある", async ({
+    page,
+  }) => {
     await page.goto("/about")
-    const link = page.getByRole("link", { name: "Read in English" })
-    await expect(link).toBeVisible()
-    await expect(link).toHaveAttribute("href", "/en/about")
+    const tab = page.getByTestId("language-tab")
+    await expect(tab).toBeVisible()
+    await expect(tab).toHaveAttribute("href", "/en/about")
   })
 
-  test("英語版ホームから日本語版への導線がある", async ({ page }) => {
+  test("英語版ホームのヘッダーに日本語版への吊り下げバーがある", async ({
+    page,
+  }) => {
     await page.goto("/en")
-    const link = page.getByRole("link", { name: "日本語で読む" })
-    await expect(link).toBeVisible()
-    await expect(link).toHaveAttribute("href", "/")
+    const tab = page.getByTestId("language-tab")
+    await expect(tab).toBeVisible()
+    await expect(tab).toHaveText(/日本語版はこちら/)
+    await expect(tab).toHaveAttribute("href", "/")
   })
 
-  test("英語版 About から日本語版への導線がある", async ({ page }) => {
+  test("英語版 About のヘッダーに日本語版への吊り下げバーがある", async ({
+    page,
+  }) => {
     await page.goto("/en/about")
-    const link = page.getByRole("link", { name: "日本語で読む" })
-    await expect(link).toBeVisible()
-    await expect(link).toHaveAttribute("href", "/about")
+    const tab = page.getByTestId("language-tab")
+    await expect(tab).toBeVisible()
+    await expect(tab).toHaveAttribute("href", "/about")
+  })
+
+  test("インデックス本文に翻訳バナーは表示されない", async ({ page }) => {
+    await page.goto("/")
+    await expect(
+      page.getByText("An English version of this article is available."),
+    ).toHaveCount(0)
+  })
+
+  test("About 本文に翻訳バナーは表示されない", async ({ page }) => {
+    await page.goto("/about")
+    await expect(
+      page.getByText("An English version of this article is available."),
+    ).toHaveCount(0)
   })
 })

--- a/scripts/build-feed.ts
+++ b/scripts/build-feed.ts
@@ -16,7 +16,9 @@ const feed = new Feed({
   copyright: `All rights reserved ${dayjs().format("YYYY")}, sh1ma`,
 })
 
-for (const article of allArticles) {
+const feedArticles = allArticles.filter((article) => article.locale === "ja")
+
+for (const article of feedArticles) {
   feed.addItem({
     title: article.title,
     description: article.description ?? "",
@@ -27,4 +29,4 @@ for (const article of allArticles) {
 
 await mkdir(OUT_DIR, { recursive: true })
 await writeFile(OUT_FILE, feed.rss2(), "utf-8")
-console.log(`Wrote ${OUT_FILE} (${allArticles.length} items)`)
+console.log(`Wrote ${OUT_FILE} (${feedArticles.length} items)`)

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -559,7 +559,7 @@ const buildArticleHtml = (
   description: string | undefined,
   locale: "ja" | "en",
 ) => {
-  const path = locale === "en" ? `articles/en/${slug}` : `articles/${slug}`
+  const path = locale === "en" ? `en/articles/${slug}` : `articles/${slug}`
   const url = `${SITE_URL}/${path}`
   const ogImage = `${SITE_URL}/og/${locale === "en" ? `en/${slug}` : slug}.png`
   const desc = description ?? (locale === "en" ? "Blog article" : "ブログ記事")
@@ -597,7 +597,7 @@ for (const article of allArticles) {
 
   const articleDir =
     locale === "en"
-      ? path.join(DIST_DIR, "articles", "en", article.id)
+      ? path.join(DIST_DIR, "en", "articles", article.id)
       : path.join(DIST_DIR, "articles", article.id)
   await mkdir(articleDir, { recursive: true })
   const html = buildArticleHtml(

--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -557,10 +557,12 @@ const buildArticleHtml = (
   slug: string,
   title: string,
   description: string | undefined,
+  locale: "ja" | "en",
 ) => {
-  const url = `${SITE_URL}/articles/${slug}`
-  const ogImage = `${SITE_URL}/og/${slug}.png`
-  const desc = description ?? "ブログ記事"
+  const path = locale === "en" ? `articles/en/${slug}` : `articles/${slug}`
+  const url = `${SITE_URL}/${path}`
+  const ogImage = `${SITE_URL}/og/${locale === "en" ? `en/${slug}` : slug}.png`
+  const desc = description ?? (locale === "en" ? "Blog article" : "ブログ記事")
   const meta = [
     `    <meta property="og:type" content="article" />`,
     `    <meta property="og:title" content="${escapeHtml(title)}" />`,
@@ -580,23 +582,30 @@ const buildArticleHtml = (
 }
 
 await mkdir(OG_DIR, { recursive: true })
+await mkdir(path.join(OG_DIR, "en"), { recursive: true })
 const fonts = await loadFonts()
 const shell = await readFile(SHELL_HTML, "utf-8")
 
 let pngCount = 0
 let htmlCount = 0
 for (const article of allArticles) {
+  const locale = article.locale === "en" ? "en" : "ja"
   const publishedAt = dayjs(article.publishedAt).format("YYYY-MM-DD")
-  await renderPng(article.id, article.title, publishedAt, fonts)
+  const ogSlug = locale === "en" ? `en/${article.id}` : article.id
+  await renderPng(ogSlug, article.title, publishedAt, fonts)
   pngCount++
 
-  const articleDir = path.join(DIST_DIR, "articles", article.id)
+  const articleDir =
+    locale === "en"
+      ? path.join(DIST_DIR, "articles", "en", article.id)
+      : path.join(DIST_DIR, "articles", article.id)
   await mkdir(articleDir, { recursive: true })
   const html = buildArticleHtml(
     shell,
     article.id,
     article.title,
     article.description,
+    locale,
   )
   await writeFile(path.join(articleDir, "index.html"), html)
   htmlCount++

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -161,7 +161,7 @@ export const BlogHeader = () => {
         {languageTarget && (
           <div
             aria-hidden={isCompact}
-            className={`pointer-events-none absolute inset-x-0 top-full z-0 flex justify-center transition-all duration-500 ease-out ${
+            className={`pointer-events-none absolute inset-x-0 top-full z-0 flex justify-start pl-6 transition-all duration-500 ease-out ${
               isCompact
                 ? "-translate-y-[calc(100%+72px)] opacity-0"
                 : "translate-y-0 opacity-100"
@@ -171,9 +171,9 @@ export const BlogHeader = () => {
               to={languageTarget.href}
               lang={languageTarget.lang}
               data-testid="language-tab"
-              className="pointer-events-auto -mt-2 inline-flex items-center gap-1.5 rounded-b-xl border border-t-0 border-white/50 bg-bg-surface/85 pb-1.5 pl-3 pr-3.5 pt-3 text-xs font-medium text-brand-primary shadow-soft backdrop-blur-xl backdrop-saturate-150 transition-colors hover:bg-bg-surface"
+              className="pointer-events-auto -mt-2 inline-flex items-center gap-1 rounded-b-lg border border-t-0 border-white/50 bg-bg-surface/85 pb-1 pl-2.5 pr-3 pt-2.5 text-[11px] font-medium text-brand-primary shadow-soft backdrop-blur-xl backdrop-saturate-150 transition-colors hover:bg-bg-surface"
             >
-              <Languages size={14} />
+              <Languages size={12} />
               {languageTarget.label}
             </Link>
           </div>

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "@tanstack/react-router"
-import { ChevronLeft, PenLine } from "lucide-react"
+import { allArticles } from "contentlayer/generated"
+import { ChevronLeft, Languages, PenLine } from "lucide-react"
 import { useCallback, useEffect, useRef, useState } from "react"
 
 const SCROLL_THRESHOLD = 80
@@ -8,6 +9,47 @@ const AUTO_COLLAPSE_DELAY_MS = 3000
 
 const glassSurface =
   "bg-bg-surface/75 border border-white/50 shadow-soft backdrop-blur-xl backdrop-saturate-150"
+
+type LanguageTarget = {
+  href: string
+  label: string
+  lang: "ja" | "en"
+}
+
+const EN_LABEL = "Read in English"
+const JA_LABEL = "日本語版はこちら"
+
+const resolveLanguageTarget = (pathname: string): LanguageTarget | null => {
+  if (pathname === "/") {
+    return { href: "/en", label: EN_LABEL, lang: "en" }
+  }
+  if (pathname === "/about") {
+    return { href: "/en/about", label: EN_LABEL, lang: "en" }
+  }
+  if (pathname === "/en") {
+    return { href: "/", label: JA_LABEL, lang: "ja" }
+  }
+  if (pathname === "/en/about") {
+    return { href: "/about", label: JA_LABEL, lang: "ja" }
+  }
+  const enArticle = pathname.match(/^\/en\/articles\/(.+?)\/?$/)
+  if (enArticle) {
+    const slug = enArticle[1]
+    const hasJa = allArticles.some((p) => p.id === slug && p.locale === "ja")
+    return hasJa
+      ? { href: `/articles/${slug}`, label: JA_LABEL, lang: "ja" }
+      : null
+  }
+  const jaArticle = pathname.match(/^\/articles\/(.+?)\/?$/)
+  if (jaArticle) {
+    const slug = jaArticle[1]
+    const hasEn = allArticles.some((p) => p.id === slug && p.locale === "en")
+    return hasEn
+      ? { href: `/en/articles/${slug}`, label: EN_LABEL, lang: "en" }
+      : null
+  }
+  return null
+}
 
 export const BlogHeader = () => {
   const pathname = useLocation({ select: (loc) => loc.pathname })
@@ -107,15 +149,37 @@ export const BlogHeader = () => {
     return "border-b-2 border-transparent pb-0.5 text-sm font-medium text-text-muted transition-colors hover:text-brand-primary"
   }
 
+  const languageTarget = resolveLanguageTarget(pathname)
+
   return (
     <div
       className={`sticky top-4 z-50 mb-8 w-full px-4 transition-opacity duration-700 ease-out sm:px-6 lg:px-8 ${
         visible ? "opacity-100" : "pointer-events-none opacity-0"
       }`}
     >
-      <div className="mx-auto max-w-3xl">
+      <div className="relative mx-auto max-w-3xl">
+        {languageTarget && (
+          <div
+            aria-hidden={isCompact}
+            className={`pointer-events-none absolute inset-x-0 top-full z-0 flex justify-center transition-all duration-500 ease-out ${
+              isCompact
+                ? "-translate-y-[calc(100%+72px)] opacity-0"
+                : "translate-y-0 opacity-100"
+            }`}
+          >
+            <Link
+              to={languageTarget.href}
+              lang={languageTarget.lang}
+              data-testid="language-tab"
+              className="pointer-events-auto -mt-2 inline-flex items-center gap-1.5 rounded-b-xl border border-t-0 border-white/50 bg-bg-surface/85 pb-1.5 pl-3 pr-3.5 pt-3 text-xs font-medium text-brand-primary shadow-soft backdrop-blur-xl backdrop-saturate-150 transition-colors hover:bg-bg-surface"
+            >
+              <Languages size={14} />
+              {languageTarget.label}
+            </Link>
+          </div>
+        )}
         <div
-          className={`${glassSurface} relative ml-auto overflow-hidden transition-[width,height,border-radius] duration-500 ease-out ${
+          className={`${glassSurface} relative z-10 ml-auto overflow-hidden transition-[width,height,border-radius] duration-500 ease-out ${
             isCompact ? "h-12 w-12 rounded-full" : "h-[72px] w-full rounded-2xl"
           }`}
         >
@@ -145,13 +209,6 @@ export const BlogHeader = () => {
                   >
                     About
                   </Link>
-                  <Link
-                    to="/"
-                    className="border-b-2 border-transparent pb-0.5 text-sm font-medium text-text-muted transition-colors hover:text-brand-primary"
-                    lang="ja"
-                  >
-                    日本語
-                  </Link>
                 </>
               ) : (
                 <>
@@ -160,13 +217,6 @@ export const BlogHeader = () => {
                   </Link>
                   <Link to="/about" className={getLinkClassName("/about")}>
                     About
-                  </Link>
-                  <Link
-                    to="/en"
-                    className="border-b-2 border-transparent pb-0.5 text-sm font-medium text-text-muted transition-colors hover:text-brand-primary"
-                    lang="en"
-                  >
-                    English
                   </Link>
                 </>
               )}

--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -83,9 +83,19 @@ export const BlogHeader = () => {
 
   const isCompact = scrolled && !userExpanded
 
+  const isEnglish = pathname === "/en" || pathname.startsWith("/en/")
+
   const isActive = (path: string) => {
     if (path === "/") {
-      return pathname === "/" || pathname.startsWith("/articles")
+      return (
+        !isEnglish && (pathname === "/" || pathname.startsWith("/articles"))
+      )
+    }
+    if (path === "/en") {
+      return (
+        pathname === "/en" ||
+        (pathname.startsWith("/en/") && !pathname.startsWith("/en/about"))
+      )
     }
     return pathname.startsWith(path)
   }
@@ -124,12 +134,42 @@ export const BlogHeader = () => {
             </Link>
 
             <nav className="hidden items-center gap-8 md:flex">
-              <Link to="/" className={getLinkClassName("/")}>
-                Articles
-              </Link>
-              <Link to="/about" className={getLinkClassName("/about")}>
-                About
-              </Link>
+              {isEnglish ? (
+                <>
+                  <Link to="/en" className={getLinkClassName("/en")}>
+                    Articles
+                  </Link>
+                  <Link
+                    to="/en/about"
+                    className={getLinkClassName("/en/about")}
+                  >
+                    About
+                  </Link>
+                  <Link
+                    to="/"
+                    className="border-b-2 border-transparent pb-0.5 text-sm font-medium text-text-muted transition-colors hover:text-brand-primary"
+                    lang="ja"
+                  >
+                    日本語
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <Link to="/" className={getLinkClassName("/")}>
+                    Articles
+                  </Link>
+                  <Link to="/about" className={getLinkClassName("/about")}>
+                    About
+                  </Link>
+                  <Link
+                    to="/en"
+                    className="border-b-2 border-transparent pb-0.5 text-sm font-medium text-text-muted transition-colors hover:text-brand-primary"
+                    lang="en"
+                  >
+                    English
+                  </Link>
+                </>
+              )}
             </nav>
           </header>
 

--- a/src/components/TranslationNotice/TranslationNotice.tsx
+++ b/src/components/TranslationNotice/TranslationNotice.tsx
@@ -1,0 +1,40 @@
+import { Link } from "@tanstack/react-router"
+import { Languages } from "lucide-react"
+
+type TranslationNoticeProps = {
+  targetLocale: "ja" | "en"
+  href: string
+}
+
+const messages = {
+  en: {
+    text: "An English version of this article is available.",
+    linkText: "Read in English",
+  },
+  ja: {
+    text: "この記事の日本語版があります。",
+    linkText: "日本語で読む",
+  },
+} as const
+
+export const TranslationNotice = ({
+  targetLocale,
+  href,
+}: TranslationNoticeProps) => {
+  const { text, linkText } = messages[targetLocale]
+  return (
+    <div
+      className="mb-6 flex items-center gap-3 rounded-lg border border-brand-primary/20 bg-brand-primary-light/10 px-4 py-3 text-sm text-text-primary"
+      lang={targetLocale}
+    >
+      <Languages size={18} className="shrink-0 text-brand-primary" />
+      <span className="flex-1">{text}</span>
+      <Link
+        to={href}
+        className="whitespace-nowrap font-medium text-brand-primary hover:underline"
+      >
+        {linkText}
+      </Link>
+    </div>
+  )
+}

--- a/src/markdown/posts/en/20230102_helloworld.md
+++ b/src/markdown/posts/en/20230102_helloworld.md
@@ -1,0 +1,61 @@
+---
+  title: "I Started a Blog"
+  publishedAt: "2023-11-09"
+---
+
+I started a blog.  
+I built it with Next.js.
+The code is public on [GitHub](https://github.com/sh1ma/blog).
+
+Since I went to the trouble of building it, I’ll explain the technology behind this blog.
+
+## Motivation for Building the Blog
+
+I was inspired by a coworker who had built a blog.  
+On top of that, I wanted a place where I could talk about technologies I like,
+but I felt hesitant to post purely self-indulgent articles on zenn, so I decided to make a blog.  
+I’ve made blogs several times before, but none of them lasted long, so this is my revenge match.
+
+## Tech Stack
+
+This time I chose Next.js + Vercel because I wanted to write it in React and wanted deployment to be easy.
+To be honest, I haven’t really kept up with recent frontend trends, so I chose technologies I’m reasonably used to.
+
+### Managing Articles
+
+When I first started building it, I expected to manage articles with microcms, and I got as far as displaying articles, but I lost motivation and stopped.
+I also had this vague feeling that depending on something external was kind of scary.
+As a result, I decided to manage articles with markdown, or rather mdx.
+
+### Design
+
+I chose [Tailwind CSS](https://tailwindcss.com/) partly because thinking up the design myself was a hassle.
+Tailwind gives you a nice set of width, padding, margin, color, and other values without requiring you to decide every specific number yourself,
+so even though I’m not used to design, I was able to make a reasonably tidy UI.
+
+### Rendering Articles
+
+This was the part I struggled with the most while building it. At first, I wrote my own code to convert `.md` files into HTML with [remark](https://github.com/remarkjs/remark)
+and feed that into [rehype](https://github.com/rehypejs/rehype).
+
+But as I kept building it, I started to feel that approach was not great, so I decided to use [mdx](https://mdxjs.com/), which Next.js officially supports.
+Apparently Next.js’s mdx support runs on top of the rehype and remark mentioned above, so it was nice not to have to handle that myself.
+
+[@tailwindcss/typography](https://tailwindcss.com/docs/typography-plugin) handles the body styling nicely.
+I was able to render things nicely without thinking about much in particular.
+
+For code snippets that appear in the body, however, I used [rehype-pretty-code](https://github.com/atomiks/rehype-pretty-code).
+This is a rehype plugin that syntax-highlights code blocks.
+There seem to be other syntax highlighting plugins too, but for example with [rehype-prism](https://github.com/mapbox/rehype-prism),
+it seems [parsing can break](https://blog.ojisan.io/use-shiki/), so I decided to use rehype-pretty-code this time.
+
+### Deployment
+
+I used Vercel for deployment. Since Vercel officially supports Next.js, I was able to deploy with zero config.
+Vercel is the best!
+
+## Summary
+
+That’s about it for the minimal blog setup.
+There are still several features I want to add and parts I want to refine, so I hope I can keep updating it little by little.
+I also hope I can leisurely increase the number of articles.

--- a/src/markdown/posts/en/20231110_cloudflare_domain.md
+++ b/src/markdown/posts/en/20231110_cloudflare_domain.md
@@ -1,0 +1,26 @@
+---
+  title: "A Redirect Loop Occurs When Using a Domain Managed by Cloudflare on Vercel"
+  publishedAt: "2023-11-10"
+---
+
+I got stuck when trying to connect my blog deployed on Vercel to `blog.sh1ma.dev`, a subdomain of `sh1ma.dev` managed by cloudflare.  
+Specifically, a large number of redirects occurred and the forwarding setup did not work properly, so I’ll write down how I solved it.
+
+## Conclusion
+
+The answer was written in [ERR_TOO_MANY_REDIRECTS · Cloudflare SSL/TLS docs](https://developers.cloudflare.com/ssl/troubleshooting/too-many-redirects/).
+
+> After you add a new domain to Cloudflare, your visitors’ browsers might display ERR_TOO_MANY_REDIRECTS or The page isn’t redirecting properly errors.
+> This error occurs when visitors get stuck in a redirect loop.
+
+It also says this error can be caused by the following three things.
+
+- > A misconfiguration of your SSL/TLS Encryption mode. (A misconfiguration of the SSL/TLS encryption mode)
+- > Various settings in SSL/TLS > Edge Certificates. (Settings in SSL/TLS > Edge Certificates)
+- > A misconfigured redirect rule. (A misconfigured redirect rule)
+
+In my case, it was the first one: a problem with the encryption mode.
+
+Go to the Cloudflare dashboard, then the “SSL/TLS” page -> the “overview” page,
+and set SSL/TLS encryption mode to `Full` as shown in the image below. That fixed it.
+![Screenshot of the Cloudflare dashboard](https://cdn.sh1ma.dev/20231110.png)

--- a/src/markdown/posts/en/20231117_cloudflare_workers.md
+++ b/src/markdown/posts/en/20231117_cloudflare_workers.md
@@ -1,0 +1,117 @@
+---
+  title: "I Heard WASI Can Be Used on Cloudflare Workers, So I Tried It"
+  publishedAt: "2023-11-17"
+---
+
+I saw [an article saying WASI can apparently be used on Cloudflare Workers](https://blog.cloudflare.com/announcing-wasi-on-workers/)
+and thought it was amazing, so I tried it.
+
+## Environment
+
+- rustc 1.73.0
+- Cloudflare Workers
+- npm
+  - Required to run `npx wrangler@wasm`
+- wasmtime
+
+## Main Topic
+
+### Preparation
+
+Since we’ll use `wasm32-wasi` as the build target, install `wasm32-wasi`.
+
+```sh
+rustup target add wasm32-wasi
+```
+
+First, create a project with `cargo new`.
+
+```sh
+cargo new hello_world
+```
+
+Try running it once.
+
+```sh
+cargo run
+```
+
+Naturally, the output is as follows.
+
+```
+Hello, world!
+```
+
+Build this to wasm.
+
+```sh
+cargo build --target wasm32-wasi --release
+```
+
+A `hello_world.wasm` file is created in `target/wasm32-wasi/release`.
+
+I wanted to check locally whether the wasm runs, so I tried using the wasm runtime [wasmtime](https://wasmtime.dev/).
+
+First, install wasmtime.
+
+```sh
+curl https://wasmtime.dev/install.sh -sSf | bash
+```
+
+Next, try running the wasm.
+
+```sh
+wasmtime target/wasm32-wasi/release/hello_world.wasm
+```
+
+This also prints `Hello, world!`. That completes the preparation.
+
+### Running It on Cloudflare Workers
+
+```sh
+npx wrangler@wasm dev target/wasm32-wasi/release/hello_world.wasm
+```
+
+```
+ ⛅️ wrangler 0.0.0-c0d7699
+---------------------------
+⬣ Listening at http://localhost:8787
+```
+
+A server starts up like this, so if you access it from a browser or similar, you should see `Hello, World!` printed.
+Apparently the main function is invoked when an HTTP request is triggered.
+
+It looks like standard input can be passed by using a POST request, so let’s try that.
+
+First, rewrite the code so it receives standard input.
+
+```rust
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input).unwrap();
+    println!("Hello, world! {}", input);
+}
+```
+
+Build it again and run it with wranlger.
+
+```sh
+cargo build --target wasm32-wasi --release
+npx wrangler@wasm dev target/wasm32-wasi/release/hello_world.wasm
+```
+
+Send a POST request with curl.
+
+```sh
+curl -X POST -d sh1ma https://localhost:8787
+```
+
+The response was `Hello, World! sh1ma`.
+
+## Summary
+
+In this way, I was able to run an ordinary rust program on Cloudflare Workers.
+
+That said, at the moment it apparently isn’t possible to call APIs like Cloudflare d1 from WASI? (I heard this from someone.)
+
+I’m thinking of using this to make a Function that returns images with exif removed, so if I manage to do it, I’ll probably put the code on github.

--- a/src/markdown/posts/en/20240101_akeome.md
+++ b/src/markdown/posts/en/20240101_akeome.md
@@ -1,0 +1,24 @@
+---
+  title: "Happy New Year"
+  publishedAt: "2024-01-01"
+---
+
+Happy New Year.
+
+Last year, around August, I started working as a contractor, and since then I’ve been doing my best to get used to the new environment.  
+This year I want to devote myself to being able to contribute more.
+
+Now then, I haven’t really set goals every year,
+but this year I felt like trying to accomplish something, so I want to decide on some goals.
+
+So here they are:
+
+- Read 10 books
+- Lose 5kg
+- Write at least one article per month
+- Get an ordinary driver’s license (AT)
+  - I’m planning to join a driving school camp from 1/31
+
+I hope I can achieve them.
+
+With that, I look forward to this year as well.

--- a/src/markdown/posts/en/20240108_from_asdf_to_mise.md
+++ b/src/markdown/posts/en/20240108_from_asdf_to_mise.md
@@ -1,0 +1,130 @@
+---
+  title: "Moving from asdf and direnv to mise"
+  publishedAt: "2024-01-08"
+---
+
+Until now, I had been using [asdf](https://asdf-vm.com/) to manage runtime versions for things like python and nodejs,
+and direnv to manage environment variables per directory,
+but recently I found a version management tool called [mise](https://mise.jdx.dev/) that looked pretty good, so I decided to install it.
+
+## Uninstalling asdf and direnv
+
+I had installed them with homebrew, so I uninstalled them with `brew uninstall`.
+
+```bash
+brew uninstall asdf direnv
+brew autoremove
+```
+
+## Installing mise
+
+The steps from [mise Getting Started](https://mise.jdx.dev/getting-started.html) seem to work as-is.
+
+For optional settings and details, the official documentation is more thorough.
+
+```bash
+curl https://mise.jdx.dev/install.sh | sh
+```
+
+Add the path to `.zshrc`.
+
+```sh
+eval "$(~/.local/bin/mise activate zsh)"
+export PATH="$HOME/.local/share/mise/shims:$PATH"
+```
+
+After restarting the terminal, the `mise` command should be available. Check that it works.
+
+```bash
+mise -V
+```
+
+Output:
+
+```
+2024.1.12 macos-arm64 (3750934 2024-01-07)
+```
+
+Looks good.
+
+## Using mise
+
+Let’s try using it right away.
+
+mise has the following two kinds of functionality.
+
+- Runtime version management
+- Environment variable management per directory
+
+Both seem useful, so I’ll try them.
+
+### Runtime Version Management
+
+First, install the Node.js 20 series.
+
+```bash
+mise use --global node@20
+node -v
+```
+
+Output:
+
+```
+v20.10.0
+```
+
+Hmm, nice. I’m happy that it installs automatically if you only specify the major version.  
+By the way, when I ran `mise use` in a directory with a `.tool-versions` file, it automatically installed the specified version if it was missing.
+
+## Environment Variable Management per Directory
+
+Next, I’ll try environment variable management per directory.  
+Unlike direnv, it seems you create a file called `.mise.toml` instead of `.envrc`. (There are also methods/settings for using .envrc, but I’ll omit them.)
+
+Enter an appropriate directory and create `.mise.toml`.
+
+```toml
+[env]
+HELLO = "WORLD"
+```
+
+To enable it, it seems you need to run `mise trust`, similar to `direnv allow` in `direnv`.
+
+```bash
+mise trust
+```
+
+Output:
+
+```
+mise trusted /Users/sh1ma/tmp/.mise.toml
+```
+
+You can display environment variables with `mise env`.
+
+```bash
+mise env | grep HELLO
+```
+
+Output:
+
+```
+export HELLO=WORLD
+```
+
+```bash
+echo $HELLO
+```
+
+Output:
+
+```
+WORLD
+```
+
+Looks good.
+
+## Summary
+
+I wasn’t dissatisfied with asdf and direnv, but it feels cleaner to have consolidated two tools into one.  
+Oh, I need to remember to add `.mise.toml` to the `.gitignore` in my home directory.

--- a/src/markdown/posts/en/20240128_iterm2_word_backwards_forwards.md
+++ b/src/markdown/posts/en/20240128_iterm2_word_backwards_forwards.md
@@ -1,0 +1,32 @@
+---
+  title: "Making Word Movement Work in iTerm2 with Option + Arrow Keys"
+  publishedAt: "2024-01-28"
+---
+
+Even though I’ve used iTerm2 for many years, I had never properly configured word movement.  
+I really wanted to move by word with `Option + <arrow key>`, so this time I made it possible to move by word using the arrow keys together with Option.
+
+## How to Configure It
+
+There are two ways: change the “Global Keymap”, or configure it per iTerm2 profile.  
+I chose not to change the global keymap and instead only changed iTerm2’s default profile.  
+The method explained below changes only the default profile.
+
+### 1. Go to the Keys tab from iTerm2 settings and open Key Mappings.
+
+![Screenshot of the screen after opening the Key Mappings tab in iTerm2](https://cdn.sh1ma.dev/20240128-1.png)
+
+It looks like this.
+
+### 2, Press the “+” button at the bottom of the screen to add a new key mapping.
+
+![Screenshot while assigning a shortcut for Option + → from the Key Mappings tab](https://cdn.sh1ma.dev/20240128-2.png)
+
+When you click the “Keyboard Shortcut” field, it waits for shortcut key input, so enter `Option + →`.
+
+For Action, select “Send Escape Sequence” and enter `f`.  
+This means that when `Option + →` is pressed, it sends `Esc + f`. (In iTerm2, `Esc + f` is the default shortcut for word movement.)
+
+Using the same steps, set `Option + ←` to `Esc + b`.
+
+Once you save the settings, you’re done.

--- a/src/markdown/posts/en/20240201_driving_school.md
+++ b/src/markdown/posts/en/20240201_driving_school.md
@@ -1,0 +1,129 @@
+---
+  title: "I Joined a Driving School Camp"
+  publishedAt: "2023-02-25"
+---
+
+I joined a driving school camp to get an ordinary vehicle class 1 license. I chose [Sohgoh Driving School](https://www.sohgoh.co.jp/) as the school.
+
+This was actually my third attempt to get a license. It was my second driving school camp.
+
+I think the first time I tried to get a license was when I was 19 or 20.  
+I wanted to get it early, so I chose a camp and went all the way to Yamagata, but I went home on the second day because of homesickness.  
+Well, strictly speaking it wasn’t homesickness.
+At the time, I wasn’t in good mental shape to begin with, and when I arrived at a rural inn with not a single shop around, I started feeling like, “Ah, I can’t survive here alone,” my mental state collapsed, and I dropped out.
+They told me to pay the learner’s permit exam fee in cash, but there was nowhere near the school or inn where I could withdraw money. I thought I was completely stuck.
+
+For the second attempt, taking the previous failure into account, I tried to get it at a local driving school. And in MT, no less. I thought, “If I commute, it’ll be easy,” and underestimated it, then failed spectacularly.  
+But, you know, I was close. Seriously close.
+
+I had already gotten the learner’s permit and had finished all the second-stage classroom lessons. But at that time I was also working in parallel, and my mental state was not good. Sorry for being alive.
+I dropped out at the point where all I had left was three more practical lessons and passing the graduation test. Why would I drop out there...? And it was MT, too.
+
+But from those two failures, I learned the following:
+
+- _Do not try to get a license when your mental state is bad (because when your mental state is bad, you become unable to take lessons)_
+- _Do not try to get a license while working (because you get exhausted and your mental health collapses)_
+- _For driving school camp, choose WAO! and a place with a convenience store (because if you go to the countryside, your heart breaks and your mental health collapses)_
+
+Apparently someone with an extremely weak mental state like me needs some ingenuity to get a license.
+
+Honestly, I thought commuting was no longer realistic. Going there itself takes stamina, of course, but the biggest problem is time.
+Because I work (almost) full-time, it’s difficult to secure the time.
+That means the only path left for me is driving school camp.
+
+So this is my report on trying driving school camp.
+
+## Until Getting the Learner’s Permit
+
+Driving school courses are divided into two parts, called “Stage 1” and “Stage 2”. Since you cannot take Stage 2 unless you finish Stage 1 and obtain a learner’s permit,
+after enrollment you first aim to get a learner’s permit in Stage 1.
+
+### First Day
+
+We gathered at Hamamatsu Station at 10:40.  
+I arrived early, so I ended up waiting for the other camp participants to arrive, but at that point there were already people who had become friendly with each other, and I panicked quite a bit.
+
+**“I have to somehow talk to someone too...!”**
+
+Driven by that panic, I gathered my courage on the shuttle bus from the station to the driving school and spoke to a young man who seemed friendly.
+Apparently he was 18, and on top of that, a high school student. I see. People who take driving school camps at this time of year are mostly students.... When I realized that, my own behavior felt inappropriate for my age, and I got embarrassed.
+
+By the way, after arriving at the driving school and finishing the aptitude test, I noticed that the guy I had just talked to on the bus was gone. Apparently he failed the aptitude test and was sent home. I didn’t know it was possible to fail an aptitude test....
+
+After that, we received explanations about the accommodation facility and the rules while enrolled, took the first practical lesson, and then went back to the hotel.
+
+### From Day 2 Until the Learner’s Permit Exam Day
+
+I couldn’t make any friends, so in the end I spent the time alone.  
+Well, I thought maybe I could use the gaps in the schedule to work or something, but I made absolutely no progress and gave up on working partway through.  
+I was lonely, so every night I joined voice chat on a private Discord server with friends, and that was my only conversation outside the day’s lessons. I want to thank the friends who kept me company.
+
+In the practical lessons, from the first day I was told things like “You’re good,” but of course I was. It was my second time trying to get a license. I was able to proceed through the curriculum without any particular problems until the exam day.
+
+The classroom lessons were online lectures, where I watched video lessons from my own device in my hotel room.  
+Since I only had to finish all 10 video lessons by the learner’s permit exam, I thought, “It’s great that I can finish everything just by playing the videos,” but I had to turn on the camera so they could check my attitude, and because of the system specification that the lesson forcibly ends if your attitude is bad, I ended up listening seriously.  
+That said, if you listen seriously, the later written exams become easier, so it turned out to be good.
+
+And before taking the learner’s permit exam, I had to take something called an effectiveness measurement. This was 50 true/false questions worth 2 points each, with a passing line of 90 points. In other words, you pass with 45 correct answers. I had to pass this by the learner’s permit exam day. If I couldn’t, an extended stay was confirmed.
+I was surprised that it was suddenly put into my schedule from the second day, but I somehow passed on the first try. I scored 92.
+
+### Learner’s Permit Exam Day
+
+The learner’s permit exam is divided into a “completion test” and a “learner’s permit written exam”. Only people who pass the completion test can take the learner’s permit written exam, and if you pass that, you can obtain a learner’s permit.
+
+That day, during the waiting time before the completion test, two people from my cohort (?) talked to me, and when I responded while grinning, we became friendly. That day we ate together and chatted.
+I ended up staying friends with those two until the final day of the driving school camp.
+
+I was very nervous on the day of the exam, but talking to people eased my nerves, and I was able to pass without issue.
+
+## Until the Graduation Test
+
+Immediately after getting the learner’s permit, you start Stage 2 lessons. On the very day I passed the learner’s permit written exam, I suddenly had to take a Stage 2 on-road lesson.
+
+In reality, aside from going out onto the road for lessons, there is nothing different from getting the learner’s permit, so there isn’t much to write.
+
+But unlike during the learner’s permit phase, I was able to eat lunch and talk with friends between lessons, so it was fun.
+
+### Graduation Test
+
+The graduation test is only a practical test. That is because the written exam is taken at your local driver’s license center.
+
+The graduation test consists of “on-road driving + (direction change | parallel parking)”, and whether it is direction change or parallel parking apparently depends on the test route. (I think there were about 6 or 7 test routes.)
+For me, the route was somehow one with a low difficulty level, but early on I slammed the brake hard, so honestly I thought I might have failed, but I passed. Nice. I was heavily criticized after the test, though.
+
+## Things Other Than Lessons
+
+### Accommodation
+
+The accommodation was [Kuretake Inn Central Hamamatsu](https://kuretake-inn.com/hotel/hamamatsu-central).
+
+Half of the room was filled by the bed, and half of the remaining half was filled by the desk.  
+It felt cramped, but as long as I didn’t spread out my luggage too much, it was enough space for a person to live, so I figured it was fine.
+
+### Meals
+
+Breakfast was buffet style. I ate only one plate of fruit punch every day.  
+Lunch was at the driving school cafeteria. It wasn’t incredibly delicious, but it tasted okay enough to eat.
+
+Dinner was the problem.  
+For dinner, the hotel gave us “meal coupons”, and the system was that if you used them at designated restaurants, you could get 1000 yen off.  
+At first I thought, “Free eating out is the best!”, but there were fewer places to eat than I expected. (More precisely, the designated restaurants were far away and such.)
+Before the learner’s permit exam, I ate pilaf almost every day at a suspicious (?) Asian restaurant called [Sarasaya](https://maps.app.goo.gl/uUmUxG5jP9ox6zBSA) in front of the hotel.
+It was fairly spicy, but after the learner’s permit exam I was able to go eat with friends, so I looked forward to it quite a bit every day.
+
+Also, I forgot which day it was, but I went to [Charcoal-Grilled Restaurant Sawayaka Hamamatsu Entetsu](https://g.co/kgs/HZdQeTc). I got a numbered ticket around 11, waited about two hours from there (!), and then was able to enter.  
+As for the taste, to be honest, I felt like, “I waited two hours for this...?” But I guess it was more of a commemorative thing.
+
+### Other Notes
+
+- I bought nail clippers and an ear pick partway through. I thought people who are worried should probably bring them
+- The bed in the room is insanely hard. It’s no different from sleeping on concrete, so you should be prepared.
+- If you return to the hotel too early, you can’t enter your room because they say things like “We’re cleaning,” so be careful. I messed this up about twice. On days when lessons ended at 11, I couldn’t go back until 15:00, which was painful.
+
+## Summary
+
+- I went to a driving school camp
+- Even a socially maladjusted person could graduate
+- I happened to make friends too
+
+That’s all.

--- a/src/markdown/posts/en/20240229_driving_license.md
+++ b/src/markdown/posts/en/20240229_driving_license.md
@@ -1,0 +1,69 @@
+---
+  title: "I Got an Ordinary Driver’s License"
+  publishedAt: "2024-02-29"
+---
+
+The other day, [I joined a driving school camp and graduated successfully](/articles/20240201_driving_school).\_\_
+After that, I took the final written exam at the driver’s license center and passed successfully, so this is my report.
+
+## Until the Exam
+
+Apparently both the process leading up to the exam and the difficulty of the exam differ by region, but I took it in Kanagawa Prefecture.
+
+More detailed information than what I write here is written here:
+
+[Exam Procedures for an Ordinary License (Designated School Graduates): For Those Taking the Written Exam for the First Time After Graduating from a Designated Driving School (Including Out-of-Prefecture Schools) / Kanagawa Prefectural Police](https://www.police.pref.kanagawa.jp/tetsuzuki/menkyo/mes83010.html)
+
+The exam is held in the morning and afternoon, with the morning session for graduates of driving schools within the prefecture and the afternoon session for graduates of driving schools outside the prefecture.
+Since I graduated from a driving school camp, I was a graduate of an out-of-prefecture driving school, so I took the afternoon exam.
+
+In Kanagawa Prefecture, you need to make a reservation to take the final written exam.  
+Reservations can be made online, though apparently they also accept phone reservations if you really cannot reserve online.
+
+If you enter “運転免許学科試験” in the search field on the page below, you can check available slots and make a reservation from there.
+
+[e-kanagawa Electronic Application: Procedure Application List](https://dshinsei.e-kanagawa.lg.jp/140007-u/offer/offerList_initDisplay.action#application)
+
+More detailed information can be found below.
+
+[About Online Reservations for Written Exams / Kanagawa Prefectural Police](https://www.police.pref.kanagawa.jp/tetsuzuki/menkyo/mes83125.html)
+
+#### About “Application Form Number, etc.”
+
+When making a reservation, there is a field for “申請書番号等”, and you can simply enter the “No. xxx” number written on your graduation certificate.
+
+## Exam Day
+
+On exam day, you go to the driver’s license center, complete reception and the aptitude test, and then take the exam.
+What you need to bring is writing utensils, your resident certificate, and your graduation certificate.
+
+### Reception
+
+Reception starts at 13:00, but I arrived at 12:30. There was already a line at that time, so it might be good to go a little earlier.
+When you show your graduation certificate at reception, they hand you an application form while giving an explanation, but they speak too quickly to understand, so it’s fine to ignore it.
+All the places you need to fill in and the explanations are written at the writing tables behind reception.
+
+### Aptitude Test
+
+The aptitude test is only an eyesight test.  
+It’s the usual thing, like where the gap is in the ring ([Landolt ring](https://www.skk-net.com/health/me/c02_0202.html)).
+
+### Written Exam
+
+Once the aptitude test is over, you are guided to the venue where you take the written exam.  
+When the time comes, an explanation of the written exam begins, and then the exam starts.
+
+I’ll omit the exam contents, but it was easier than I expected. (I was nervous because I had scored 89 on a past-question-style set I solved right before.)
+You could submit the exam and leave after 30 minutes had passed.
+
+We had to wait nearly an hour for the results, and apparently because of a system issue? they announced them verbally.
+Numbers were called in order, and people whose numbers were called were taken outside. The people left in the room were the ones who passed.
+
+### After the Exam
+
+After passing, you take the license photo, and then receive your driver’s license.
+
+## Impressions
+
+For now, I’m glad I passed.
+I was able to prove that even a socially maladjusted person like me can get a license.

--- a/src/markdown/posts/en/20240430_nichijou.md
+++ b/src/markdown/posts/en/20240430_nichijou.md
@@ -1,0 +1,30 @@
+---
+  title: "How I Feel Now About Wanting to Die"
+  publishedAt: "2024-04-30"
+---
+
+It has been a long time since the desire to die stopped welling up in me.  
+It began around the summer of fourth grade, and at the end of the year before last, the feeling that had lived inside me disappeared.
+
+Why did it disappear? Because I got treatment.  
+Why did I get treatment? Because I wanted to be freed from the pain.
+
+Being in a state of wanting to die is painful. In my case (and this may be true for many people who want to die), I was tormented by the dilemma between “the desire to die” and “the reality that I cannot die,” and that was unbearably painful.  
+(I would also like to write about the details of this pain and an examination of the emotions that people who want to die may have, but I’ll omit that in this article.)  
+In any case, I wanted to escape that suffering as soon as possible. And this time, the place I happened to escape to was not “suicide” but “treatment.”
+
+I began seriously facing treatment in the second half of the year before last, but until then, to be honest, I did not believe in medical care related to the mind. I thought “the desire to die” was something innate, that it and I were bound together, and that it would never peel away from me.
+Even now, I have not ultimately come to believe that. However, when a doctor told me, “You are a patient with typical symptoms,” I feel like a faint expectation began to sprout inside me for the first time: “If it is typical, then maybe it can be treated according to the theory.”
+And I have continued treatment until today, and now I have recovered to the point where I can work.
+
+Now, I’ll talk about the present, after remission.  
+My family and the people around me told me, “It’s good that your symptoms are gone.”  
+It is a happy thing to have escaped the suffering, and from the bottom of my heart I’m glad I got treatment.
+
+Since then, I feel like there has been a period of about a year during which I have not wanted to die. It feels deeply moving, and for some reason a little lonely too.
+
+In conclusion, right now I do not want to die.  
+But if asked whether that means “I want to live,” it does not. While I do not think “I want to die,” I also do not think “I want to live.”  
+And I feel that this is a dangerous state, like standing at the edge of a large hole.
+Because the version of me that neither wants to live nor wants to die is afraid that, with some small trigger, I might suddenly be returned to a state of wanting to die. It feels like if I were pushed just a little, I would fall into a large hole.  
+So now, I spend my days afraid of something that might push me into that hole.

--- a/src/markdown/posts/en/20240609_blog_moves_to_cloudflare_pages.md
+++ b/src/markdown/posts/en/20240609_blog_moves_to_cloudflare_pages.md
@@ -1,5 +1,5 @@
 ---
-title: Moving Blog Hosting from Vercel to Cloudflare Pages: ContentLayer Edition
+title: "Moving Blog Hosting from Vercel to Cloudflare Pages: ContentLayer Edition"
 publishedAt: "2024-06-09"
 ---
 

--- a/src/markdown/posts/en/20240609_blog_moves_to_cloudflare_pages.md
+++ b/src/markdown/posts/en/20240609_blog_moves_to_cloudflare_pages.md
@@ -1,0 +1,147 @@
+---
+title: Moving Blog Hosting from Vercel to Cloudflare Pages: ContentLayer Edition
+publishedAt: "2024-06-09"
+---
+
+I missed writing a blog post in May. In my [2024 Happy New Year article](https://blog.sh1ma.dev/articles/20240101_akeome), I had declared, “I’ll write a blog once a month,” yet it collapsed after only four months... I lack determination.
+
+Yesterday I felt like it was about time to write a blog article, but then I thought I wanted to migrate the blog to Cloudflare, do “real Web” with Edge Runtime, and go to the promised land. After fiddling with the code, the migration succeeded, so this article is an attempt to leave notes on that process. I’m writing from memory, so there may be parts I don’t remember accurately. (I actually wanted to write about a smart speaker I recently made, but I’ll save that for another time.)
+
+This time I’ll talk about the part where I introduced contentlayer.
+
+## Problem
+
+[Next.js can be deployed to Cloudflare Pages](https://nextjs.org/docs/app/api-reference/edge) by using Edge Runtime.  
+In Edge Runtime, APIs based on Web standards are available, while packages that use some Node.js APIs such as `fs` and `path` cannot be used. However, this blog depended on Node.js APIs such as `readdir()` from `fs/promises` and `path.join()`, so it could not be migrated as-is.
+
+For example, the following kind of code existed for getting the article list.
+
+```ts
+// readdir, pathのimport
+import { readdir } from "fs/promises"
+import path from "path"
+
+// 記事一覧を取得する関数
+// これを記事一覧ページで使っていた
+export const getArticles = async () => {
+  // .mdxファイルがあるディレクトリからファイル一覧を取得
+  const postDirPath = path.join(process.cwd(), "src/markdown/posts")
+  const postFilePaths = await readdir(postDirPath)
+
+  const postMetas = await Promise.all(
+    // ファイルパス一覧をmapで処理していく
+    postFilePath
+      .map(async (filePath) => {
+        // .mdxファイルから`meta`を一度インポートする。
+        // `meta`にはタイトルの情報と公開日の情報が含まれている
+        const { meta } = (await import(`@/markdown/posts/${filePath}`)) as {
+          meta: { title: string; publishedAt: string }
+        }
+
+        // metaと記事のidを生成して返す
+        return { ...meta, id: filePath.replace(/\.mdx$/, "") }
+      })
+      // ソートして降順にする
+      .sort()
+      .reverse(),
+  )
+  return postMetas
+}
+```
+
+Unfortunately, there is nothing in edge runtime that can replace `readdir` or `path.join`. So in this case, it was necessary to fundamentally reconsider the method of “retrieving information from the file system.”
+
+## Solution
+
+In the first place, information such as the article list is determined at build time, so it does not need to be generated dynamically. That means it is enough if the article list can be generated at build time.  
+While looking for a good tool, I found a tool called [contentlayer](https://contentlayer.dev/).
+
+contentlayer is a tool for converting information from so-called content files such as .md files into json and making it easy to import into a typescript application.
+
+The conversion from .md files to json only runs once at build time, it provides objects such as `allArticles` (the name `Article` depends on the configuration) for retrieving file lists, and it also adds types to the generated output, and so on... It seemed capable of meeting the earlier goal, and I could also enjoy the advantages above, so this time I adopted contentlayer without comparing it with anything else.
+
+The article that led me to learn about contentlayer was the following.
+
+[Trying Contentlayer, Which Is Very Useful for Personal Blog Development | stin's Blog](https://blog.stin.ink/articles/introduce-contentlayer)
+
+Setup is explained in the [official Getting Started](https://contentlayer.dev/docs/getting-started-cddd76b7), and by following the steps I was able to introduce it without getting particularly stuck.
+
+During setup, I needed to edit a contentlayer configuration file called `contentlayer.config.ts`. Among other things, I had to write a definition for md files like the following, so I’ll show it along with explanatory comments.
+
+```ts
+
+// 記事のmarkdownファイルの定義
+export const Article = defineDocumentType(() => ({
+  // ここで指定した名前が生成される型の名前になります
+  name: "Article",
+  // どのようなフォルダに入っているか指定します
+  // ここではフルパスは指定しません
+  // 下記のmakeSourceに渡すパスの以下をここに記述すればよいです
+  filePathPattern: `**/posts/*.md`,
+  // contentType: "mdx",
+
+  // フィールドの設定です
+  // フィールドではmarkdownのyaml headerに書かれたmetadataを定義しておきます
+  fields: {
+    title: { type: "string", required: true },
+    publishedAt: { type: "date", required: true },
+  },
+  // computedFieldsは生成時に自動で計算されるメタデータです
+  // 自分は記事のidを.mdファイルのファイル名にしたかったのでその定義を行いました
+  computedFields: {
+    id: {
+      type: "string",
+      resolve: (doc) => doc._raw.sourceFileName.replace(/\.md$/, ""),
+    },
+  },
+}))
+
+// about.mdの設定
+export const About = ...
+
+```
+
+With the configuration above, the part that retrieves the article list only needs the following import.
+Note: `contentlayer/generated` is the path where the automatically generated json files are located.
+
+```ts
+import { allArticles } from "contentlayer/generated"
+```
+
+Previously, retrieving the body and other information for an article page looked like this ↓
+
+```ts
+const getContent = async (slug: string) => {
+  const { default: Content, meta } = (await import(
+    `@/markdown/posts/${slug}.mdx`
+  )) as { default: React.FC; meta: { title: string; publishedAt: string } }
+
+  return { Content, meta }
+}
+```
+
+After introducing contentlayer, it became the following.
+
+```ts
+import { allArticles } from "contentlayer/generated"
+const post = allArticles.find((post) => post.id === slug)
+```
+
+## Summary
+
+By introducing contentlayer, I was able to eliminate code that depended on the file system. I’m happy.
+
+At this point, support for Edge Runtime was already possible, but in order to run contentlayer on Cloudflare Pages, I had to abandon mdx. The reason is that contentlayer’s mdx support is implemented using `eval`. Cloudflare Pages (Workers) does not allow code that uses `eval`. ([EvalError: Code generation from strings disallowed for this context - Developers / Cloudflare Pages - Cloudflare Community](https://community.cloudflare.com/t/evalerror-code-generation-from-strings-disallowed-for-this-context/356430))
+
+[JavaScript and web standards · Cloudflare Workers docs](https://developers.cloudflare.com/workers/runtime-apis/web-standards/#javascript-standards)
+
+> For security reasons, the following are not allowed:
+>
+> - eval()
+> - new Function
+> - WebAssembly.compile
+> - WebAssembly.compileStreaming
+> - WebAssembly.instantiate with a buffer parameter
+> - WebAssembly.instantiateStreaming
+
+I currently wasn’t using any mdx-specific features, so I was able to migrate to ordinary md files without any particular problem.

--- a/src/markdown/posts/en/20240725_20240725_proxmox-gpu-passthrough.md
+++ b/src/markdown/posts/en/20240725_20240725_proxmox-gpu-passthrough.md
@@ -1,0 +1,193 @@
+---
+title: GPU Passthrough of an RTX3060 to a Proxmox VM
+publishedAt: "2024-07-25"
+---
+
+I have to write a blog post...  
+I’ve done various things recently, but it’s sad that I haven’t really recorded them on the blog.
+
+This time I was able to run Ollama using a GPU on a Proxmox VM, so I’ll write down what I did as a memo.
+
+## Environment
+
+```
+pve-manager/8.2.4/faa83925c9641325 (running kernel: 6.8.8-3-pve)
+```
+
+Also an OC model RTX3060.
+
+## Things to Do in Advance Outside Proxmox
+
+- Enable IOMMU (Intel VT-d or AMD-Vi)
+  - You can enable it from the BIOS
+
+## Steps
+
+### 1. First, Check Whether the GPU Is Inserted
+
+There might be cases where it isn’t recognized.
+`lspci{:sh}` is a command that lists PCI devices.
+`lspci -nn{:sh}` outputs device names and device IDs.
+
+```sh
+lspci -nn | grep -i nvidia
+```
+
+It generally outputs something like the following.
+
+```
+01:00.0 VGA compatible controller [0300]: NVIDIA Corporation GA106 [GeForce RTX 3060 Lite Hash Rate] [xxxx:xxxx] (rev a1)
+01:00.1 Audio device [0403]: NVIDIA Corporation GA106 High Definition Audio Controller [yyyy:yyyy] (rev a1)
+```
+
+Make a note of `xxxx:xxxx` and `yyyy:yyyy` because they will be used later.
+
+### 2. Enable IOMMU
+
+**(Optional) Check whether IOMMU is enabled**
+
+The command for checking is as follows.
+`dmesg{:sh}` is a command that lets you see the kernel’s boot output. If information related to IOMMU does not appear there, it probably isn’t enabled.
+
+```sh
+dmesg | grep -e DMAR -e IOMMU
+```
+
+If you are using an AMD CPU, output like this appears.
+
+```
+[    3.358781] pci 0000:00:00.2: AMD-Vi: IOMMU performance counters supported
+[    3.426345] perf/amd_iommu: Detected AMD IOMMU #0 (2 banks, 4 counters/bank).
+```
+
+Reference: [PCI Passthrough - Proxmox VE](https://pve.proxmox.com/wiki/PCI_Passthrough#Verify_IOMMU_is_enabled)
+
+To do GPU passthrough to a VM, PCI passthrough is required, and to do PCI passthrough, IOMMU must be enabled. This allows devices on the host machine to be used from within the VM.  
+To enable IOMMU, you need to adjust kernel parameters, and that can be done by editing the bootloader configuration `/etc/default/grub`.
+
+#### Main Topic
+
+Open `/etc/default/grub` in your favorite editor.
+
+```sh
+vim /etc/default/grub
+```
+
+Find the line that looks like the following.
+
+```sh
+GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+```
+
+You edit this part, but the setting differs depending on whether you are using an Intel CPU or an AMD CPU.  
+I am using an AMD CPU, so I configured it as follows.
+
+```sh
+GRUB_CMDLINE_LINUX_DEFAULT="quiet amd_iommu=on"
+```
+
+If you are using an Intel CPU, it is as follows.
+
+```sh
+GRUB_CMDLINE_LINUX_DEFAULT="quiet intel_iommu=on"
+```
+
+After changing and saving it, run the following command.
+
+```sh
+update-grub
+```
+
+Reboot once to apply the settings.
+
+```sh
+reboot
+```
+
+Reference: [PCI Passthrough via OVMF - ArchWiki](https://wiki.archlinux.jp/index.php/OVMF_%E3%81%AB%E3%82%88%E3%82%8B_PCI_%E3%83%91%E3%82%B9%E3%82%B9%E3%83%AB%E3%83%BC#IOMMU_.E3.81.AE.E6.9C.89.E5.8A.B9.E5.8C.96).  
+Reference: [Kernel Parameters - ArchWiki](https://wiki.archlinux.jp/index.php/%E3%82%AB%E3%83%BC%E3%83%8D%E3%83%AB%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF)
+
+### 3. Loading VFIO Modules
+
+Load the kernel modules called VFIO. Apparently, using VFIO allows devices to be handled safely even from unprivileged userspace (= inside the VM).
+
+Add the following to `/etc/modules`.
+
+```
+vfio
+vfio_iommu_type1
+vfio_pci
+vfio_virqfd
+```
+
+Then create the VFIO configuration file `/etc/modprobe.d/vfio.conf`.  
+Use the IDs obtained earlier with `lspci -nn | grep -i nvidia{:sh}` here.
+Replace “xxxx:xxxx” and “yyyy:yyyy” below and add it.
+
+```
+options vfio-pci ids=xxxx:xxxx,yyyy:yyyy
+```
+
+Next, disable the existing drivers. This prevents the host OS (Proxmox) from using the GPU and allows only the VM to use it.
+VM
+
+```
+blacklist nouveau
+blacklist nvidia
+blacklist nvidia-drm
+blacklist nvidia-modeset
+```
+
+Update the `initramfs` information. `initramfs` is the initial RAM image, and because it contains information such as the GPU drivers from before the updates above, it needs to be updated.
+
+```sh
+update-initramfs -u
+```
+
+Finally, reboot and the host OS setup is done.
+
+```sh
+reboot
+```
+
+### 4. Setting Up the VM
+
+#### Decide the Target VM
+
+Create a new VM for GPU passthrough, or decide which existing VM to use. Apparently only one VM can use GPU passthrough.
+
+Once decided, from the Proxmox Web UI, go to the VM settings, move to the “Hardware” tab, and select “Add PCI Device”. Select the Nvidia GPU.
+
+Check “All Functions” and save.
+
+#### Install Drivers in the VM
+
+Run the following commands inside the VM.
+
+```sh
+apt update
+apt install nvidia-detect
+```
+
+Install the Nvidia GPU driver shown there with `apt install`.  
+If installing `nvidia-driver`, it is as follows.
+
+```
+apt install nvidia-driver
+```
+
+Reboot.
+
+```
+reboot
+```
+
+If the installation completed correctly, the following command should be available.
+
+```
+nvidia-smi
+```
+
+## Summary
+
+I remember there were some points where I stumbled partway through, but I’m omitting them. This should mostly work.

--- a/src/markdown/posts/en/20240731_konbini_ningen.md
+++ b/src/markdown/posts/en/20240731_konbini_ningen.md
@@ -1,0 +1,34 @@
+---
+title: "I Read Convenience Store Woman"
+publishedAt: "2024-07-31"
+---
+
+I read it two or three weeks ago, though.
+I’m not good at expressing impressions about the flow or expression of a story, and I had no intention of doing that in the first place. I decided to write this article because I wanted to write down what I thought about while reading the book.
+
+First, what I want to make clear is that the reason I thought I would read this book was not “because it won the Akutagawa Prize.” (That said, the reason I learned about the book was nothing other than “because it won the Akutagawa Prize.”)
+
+The reason I thought I would read this book was just because. That would be the end of it, but if I had to say, I was a little interested in why “a story about someone who works at a convenience store” would become a topic of conversation. Even if I had the chance to hear such a person’s story in real life, I probably wouldn’t be interested, and to me a convenience store feels like a place with little change and not much of a story worth telling, and also it was topical. It won the Akutagawa Prize. In the end, isn’t it because it won the Akutagawa Prize!
+
+I didn’t intend to write impressions along the story, but I feel like I can’t begin without introducing the story, so for now I’ll quote part of the synopsis.
+
+> Keiko Furukura, a 36-year-old unmarried woman.
+> Even after graduating from university, she never found full-time employment, and this is her 18th year working part-time at a convenience store.  
+> She has never had a boyfriend.  
+> She has continued working at Smile Mart Hiiro Station Front since it opened, seeing changing coworkers come and go, and the store is now on its eighth manager.  
+> (omitted)  
+> The convenience store, with its perfect manual, is what makes me a normal “part” of the world.  
+> A shocking realist novel that questions modern existence and shakes the boundary between normal and abnormal.
+
+Source: [What Is “Normal”? Sayaka Murata’s Shocking Work Convenience Store Woman, Which Shakes Your Values | Book - Bungeishunju](https://books.bunshun.jp/ud/book/num/9784163906188)
+
+It’s a little interesting that “36-year-old unmarried woman” is introduced as an attribute with impact. Is being unmarried at 36 not normal? In any case, within the story, “36, unmarried, and has never had a boyfriend” is treated as abnormal. It probably isn’t normal.
+
+At the beginning of the story, it is revealed that the protagonist, Keiko Furukura, was what you would call a “strange child” in childhood. There are several episodes that make you think, hmm, she certainly is a strange child, such as saying she should turn a dead bird into “yakitori (because her father likes it)” or pulling down the underwear of a teacher who had fallen into hysterics. As she reaches adolescence and learns that her family and the people around her expect her to be “normal,” she begins trying to behave normally by imitating other people.  
+If it were me, I would probably feel that the surrounding demand to “behave normally” is unreasonable, and I would think of it as a kind of oppression. Of course I would resist. But from Keiko Furukura, who is asked to be “normal,” I did not feel even the slightest rebelliousness or discomfort toward that oppression. I felt something in that like a lack of humanity, or that this itself was not normal. (However, across the work as a whole, I did not think she “lacked humanity.”)
+
+Looking at the work overall, the only time I could read genuine discomfort from Keiko was when the fact that she was living together with Shiraha, who had once worked with her, for “mutual convenience,” came to light in front of the other convenience store employees. They were supposed to be working together as one part-time team to sell products from a campaign, but everyone escalated a blunt topic related to Shiraha, who Keiko probably did not care about, and in response, the scene appears where Keiko shouts emotionally for the first time.
+
+After that, each time Keiko tells the people around her the fact that she is “living with a man,” they expand the topic on their own in the same way as before, but outside the convenience store scene mentioned above, she does not show discomfort. I thought that maybe she disliked the way the convenience store, a place she could control as part of it, was transforming into something uncontrollable.
+
+I’ve gotten tired, so I’ll stop writing for now around here. I might update this article again.

--- a/src/markdown/posts/en/20240731_proxmox_ollama.md
+++ b/src/markdown/posts/en/20240731_proxmox_ollama.md
@@ -1,0 +1,200 @@
+---
+title: Installing Ollama + OpenWebUI on a Proxmox VM
+publishedAt: "2024-07-31"
+---
+
+The other day I installed Ollama on a Proxmox VM with GPU passthrough and got as far as exposing it to the Web.
+I’ll write down what I did here while remembering it.
+
+## What This Article Covers
+
+- Making the GPU available from docker containers
+- Starting [Ollama](https://github.com/ollama/ollama) and [OpenWebUI](https://github.com/open-webui/open-webui) with `docker compose`
+
+## Assumptions
+
+The VM OS is Debian Bookworm.
+
+```
+Linux xx 6.1.0-23-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.99-1 (2024-07-15) x86_64 GNU/Linux
+```
+
+## How to Do It
+
+### 1. Install Docker
+
+[Docker’s official site has instructions for installing Docker with apt](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository), but I’ll introduce them anyway.
+
+If you pull the full command sequence from the official site first, it looks like this.
+
+```sh
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+
+# Install Docker
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+**Explanation below**
+
+If `ca-certificates` and `curl` are not installed, add them with the following.
+
+```sh
+apt update
+sudo apt install -y ca-certificates curl
+```
+
+Next, create the `/etc/apt/keyrings` directory and fetch the gpg key. Apparently these days putting keyrings under `/etc/apt/keyrings` seems to be the best approach.
+Reference: [Deprecation of apt-key and How to Handle keyrings](https://zenn.dev/kariya_mitsuru/articles/a950e0996fb703#fnref-48d3-2)
+
+```sh
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+```
+
+Add the repository. The following handles it nicely.
+
+```sh
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+```
+
+Finally, install the various docker components.
+
+```sh
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+After doing this much, the docker command should be available.
+
+### 2. Install and Configure NVIDIA Container Toolkit
+
+Installing NVIDIA Container Toolkit allows Docker containers to use the host GPU, so I’ll install it. This time I’ll install it via apt. [The official documentation also has detailed steps](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#installing-with-apt), but I’ll introduce them here too.
+
+Set up the repository for installation with the command below.
+
+```sh
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+  && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+```
+
+Install it.
+
+```sh
+sudo apt update
+sudo apt install -y nvidia-container-toolkit
+```
+
+You can check the installed command with the following.
+
+```sh
+sudo nvidia-ctk --version
+```
+
+Once you confirm it is installed, run the following. This makes NVIDIA Container Runtime available from docker.
+
+```sh
+sudo nvidia-ctk runtime configure --runtime=docker
+```
+
+Finally, restart docker.
+
+```sh
+sudo systemctl restart docker
+```
+
+This completes the NVIDIA Container Toolkit setup.
+
+### 3. Try Using Ollama and OpenWebUI
+
+You can run the Ollama Docker image with the following command.
+
+```sh
+sudo docker run -d --gpus=all -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama
+```
+
+To send a request to the api server and check whether Ollama is running, use the following.
+
+```sh
+curl http://localhost:11434
+```
+
+If it is running normally, a response like the following comes back.
+
+```
+Ollama is running
+```
+
+At this point, no models are installed, so you cannot try an LLM yet.  
+To install models through a UI and try LLMs, next I’ll use `docker compose` to start it together with OpenWebUI.
+
+Save the following code as `compose.yaml` in an appropriate directory.
+
+```yaml
+services:
+  ollama:
+    image: ollama/ollama
+    runtime: nvidia
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/app/open_webui
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434
+
+volumes:
+  ollama:
+  open-webui:
+```
+
+After saving it, run the following in that directory, and OpenWebUI should start on `0.0.0.0:8080`.
+
+```sh
+docker compose up
+```
+
+If the following output appears in the logs here, you need to review the VM settings.
+
+```
+CPU does not have vector extensions
+```
+
+This problem should be resolved by setting the `Type` field to `Host`. (Reference image below)
+
+![Proxmox VM CPU settings](https://cdn.sh1ma.dev/20240731_proxmox_ollama-1.png)
+
+That completes the setup. After that, if you access the VM’s IP from a web browser, you should be able to see OpenWebUI.

--- a/src/markdown/posts/en/20240831_furikaeri.md
+++ b/src/markdown/posts/en/20240831_furikaeri.md
@@ -1,0 +1,33 @@
+---
+title: A Story About Going to Nagoya
+publishedAt: "2024-08-31"
+---
+
+I do have a reasonable number of topics to write about on the blog, but time and energy are another matter... in other words, I lack motivation.  
+It feels impossible to write an article about a specific topic right now, so I’ll write a quick look back at my trip to Nagoya. By the way, I’m writing this article while waiting for a friend at a cafe, so when my friend arrives, I’ll wrap it up casually.
+
+The biggest event this month was, more than anything, going to Nagoya. For a little while I had wanted to try taking a long-distance solo trip by car, and since a friend lives there and it was in a just-right location, I went.  
+On the day of departure, after hanging out with friends, I got home at midnight, took a nap until 2, and left. I remember strangely not feeling tired. I was probably excited.  
+On the way, I passed through Gotemba. Honestly, I had thought that even going to Gotemba was long-distance, so when I passed through and realized I was still at the beginning, I despaired.  
+At Gotemba JCT, I switched to the Shin-Tomei Expressway. Right after entering the Shin-Tomei, it was fun that I could go up to 120 km/h and the road was wide, but after about 30 minutes I got bored and sleepy. I had thought, “There is absolutely no way I would get sleepy while driving a car. Especially not while going 120 kilometers per hour,” but it really does happen....  
+Feeling a sense of danger after being attacked by drowsiness, I took several breaks along the way. Around 3 a.m. I took my first break at Surugawan-Numazu SA, then took breaks at Shizuoka SA and Hamamatsu SA. By “break,” I mean a simple one where I went to the restroom, returned to the car, reclined the seat, and closed my eyes for about 10 minutes, but even that seemed very different from not taking any breaks at all. Driving continuously really does wear down your concentration.  
+As I drove, I felt the color of the sky changing. Toward the end, the sun had completely risen, and I became aware that I was cutting through large mountains by way of tunnels.
+
+And so I arrived in Nagoya around 6:30. I left in the middle of the night because I didn’t want to get caught in any traffic at all, but being alone in an unfamiliar place at 6:30, with a little loneliness, nothing to do, and the fatigue from staying up all night, put me in a gloomy mood.
+
+For about an hour, or maybe even close to two hours, I reclined the car seat and closed my eyes in the parking lot of a Lawson. I’m really sorry for occupying the space!
+
+After that, I killed time in various ways and checked into Tokyu Inn exactly at 15:00. I was completely exhausted both mentally and physically, so the moment I entered the hotel room, I felt incredibly saved.
+
+Now, I had been thinking I might go to sleep instantly once I got in, but I was also hungry. While I was wondering what to do, a friend contacted me with something like, “Can we meet from 18:00?” and I replied, “I can.” (Was I really in a state where I could?)
+
+There was still time until 18:00, and my friend was apparently planning to eat somewhere else, so I decided to satisfy my appetite first. I went to a place called “Yabaton,” which several friends had recommended to me before. When a friend previously showed me a photo of a Yabaton miso katsu set meal or something, I said something like, “This for just under 2000 yen?” but when I tried it, it was seriously good. I want to eat it again. I ordered the larger set meal, I think. Also, I feel like I consumed about a quarter of the mustard on the table. Sorry.
+
+After filling my stomach, I was attacked by drowsiness again, but I somehow met up with my friend. When that friend asked, “Where do you want to go?” I immediately answered, “Nagoya Castle.” Nagoya Castle, counted among Japan’s three great castles. I like Japanese history a fair amount (though for that, I didn’t know much about Nagoya Castle), so I really wanted to see it. It was a bit far, so my friend looked reluctant, but in the end they took me. I think it was about 10 minutes by bus from Sakae? Something like that.
+
+I remember that after getting off the bus, we had to walk for a while before the castle tower came into view. I think it was around 19:00 at that point. There were many people in yukata around us, so I wondered if there was a festival somewhere, but as we headed toward Nagoya Castle, I realized that their destination was inside Nagoya Castle, meaning there was a festival being held within the castle grounds.  
+Unexpectedly, I ended up jumping into a summer festival. I had not been to any kind of festival since sixth grade, so seeing people enjoying Bon dancing and food stalls lined up gave me a nostalgic feeling. The last summer vacation when I went to one, all I remembered was that every sound was loud, it was muggy, and because I disliked crowded places, I wanted to go home quickly, but I was able to genuinely enjoy that event. At a stall, my friend and I each bought a grape candy. (They gave us one more as a bonus because “you seem close.” Thank you.) That was the first time I learned that not only apple candy but grape candy exists too.
+
+And so, after enjoying the summer I had hated for the first time in more than ten years, the first day ended.
+
+My friend seems likely to arrive soon, and this is also a good stopping point, so I think I’ll end here. The second day was also fun, with things like going to see a waterfall and gazing wistfully at Lake Biwa, so I do want to write about it, but if you ask whether I’ll feel like writing another article about the Nagoya trip, I’m not sure, so this might be the end of the Nagoya story.

--- a/src/markdown/posts/en/20241026_zakki.md
+++ b/src/markdown/posts/en/20241026_zakki.md
@@ -1,0 +1,27 @@
+---
+title: 20241026 Notes
+publishedAt: "2024-10-26"
+---
+
+Where did my goal of “writing one blog post per month” go...? I was not able to write an article in September. But I want to go with the theory that if I write two this month, it’s safe. I’ll do it. So this is the first article for October.
+
+Before I knew it, the heat had disappeared, and the sun started setting earlier. A friend said, “It smells like fragrant olive.” So maybe autumn has probably begun. Come to think of it, was autumn this kind of atmosphere? I tried to remember last year, but I couldn’t do it well.
+
+From August through October, I read several works that won the Akutagawa Prize.  
+What I read was:
+
+- Mount Bari
+- Black Box
+- Idol, Burning
+- Tokyo Sympathy Tower
+
+Those four books. I can’t really give impressions, or rather, I read them a little while ago, so I don’t remember. None of them had prose that felt unpleasant to read.  
+Akutagawa Prize works are easy to read, and so far I haven’t encountered anything that felt like “this is a miss,” so I enjoy reading them. Right now I’m in the middle of reading a work called The Joy of This World. My goal this year is to read 10 books, so I think I’ll read a few more. I hope I can achieve it.
+
+## Closing
+
+I have nothing to write. There should have been several events in my life, but I don’t remember them at all. I thought I’d like to record my life so I can look back on it, because otherwise I’m in trouble at times like this.
+
+Oh, come to think of it, I bought an iPhone 16 and a 10th-generation Apple Watch. That’s about it.
+
+I’ll write one more article this month. Really.

--- a/src/markdown/posts/en/20241117_cloudflare_access_openid_connect_discord_guilds.md
+++ b/src/markdown/posts/en/20241117_cloudflare_access_openid_connect_discord_guilds.md
@@ -1,0 +1,182 @@
+---
+title: Publishing a Website Only to People in a Discord Server Using Cloudflare Access
+publishedAt: "2024-11-17"
+---
+
+I set up [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui) on my home server. I thought it would be a waste if only I used it, but I was scared to publish it to the whole world... so I made it accessible only to people who are in my private Discord server. This time I’ll introduce the steps.
+
+## Roughly What We’ll Do
+
+(If you see the following and think “I get it!”, you may not need to read the rest of the article.)
+
+Using Cloudflare Workers + Discord OAuth, build an authentication server that can be used for OpenID Connect, then register it as an authentication provider in Cloudflare Zero Trust. Check the Claims of users authenticated by Cloudflare Access and determine whether they are in the Discord server.
+
+## Main Text
+
+### Prerequisites
+
+- You have registered with Cloudflare
+- You have set up wrangler (cloudflare’s cli). [The official site explains how to set it up.](https://developers.cloudflare.com/workers/get-started/guide/)
+
+### 1. Create an App in Discord Developer Portal
+
+First, access the [Discord　Developer Portal](https://discord.com/developers/applications) and create an Application to use for authentication. Make a note of the “Client ID” and “Client Secret” under “Client information” on the “OAuth2” page.
+
+### 2. Build an Authentication Server with Cloudflare Workers
+
+You can build it yourself, but someone has already published the following implementation, so we’ll use it.
+
+[Erisa/discord-oidc-worker: Sign into Discord on Cloudflare Access, powered by Cloudflare Workers!](https://github.com/Erisa/discord-oidc-worker)
+
+First, download the repository using `git clone` or similar.
+
+```sh
+git clone https://github.com/Erisa/discord-oidc-worker
+```
+
+Set up `discord-oidc-worker`.  
+The setup method is written in the Github README, but I’ll explain it here too.
+
+First, use npm to download dependencies.
+
+```sh
+cd discord-oidc-worker
+npm install
+```
+
+Prepare [Cloudflare Workers KV](https://developers.cloudflare.com/kv/). There are two setup methods: using wrangler and clicking around in Cloudflare’s web console. wrangler is easier, so I’ll introduce that.
+
+Create a cloudflare workers KV with the following command. This KV is used to store [JSON Web Key (JWK)](https://openid-foundation-japan.github.io/rfc7517.ja.html).
+
+If your wrangler version is 3.60.0 or higher, read `kv:namespace` as `kv namespace`.
+
+```sh
+npx wrangler kv:namespace create "discord_oidc_keys"
+```
+
+If it succeeds, I think output like the following will appear.
+
+```
+🌀 Creating namespace with title "worker-discord_oidc_keys"
+✨ Success!
+Add the following to your configuration file in your kv_namespaces array:
+{ binding = "discord_oidc_keys", id = "..." }
+```
+
+Change the `binding` in `{ binding = "discord_oidc_keys", ...}` to `KV` and copy-paste it into wrangler.toml.  
+wrangler.toml will look like the following.
+
+```toml
+name = "discord-oidc"
+main = "worker.js"
+compatibility_date = "2022-12-24"
+
+kv_namespaces = [
+  { binding = "KV", id = "..." },
+]
+```
+
+Next, create config.json based on config.sample.json.
+
+```sh
+cp config.sample.json config.json
+```
+
+Edit config.json. Use the client id and client secret you noted in step 1. Rewrite it as follows.
+
+```json
+{
+  "clientId": "YOUR_DISCORD_CLIENT_ID",
+  "clientSecret": "YOUR_DISCORD_CLIENT_SECRET",
+  "redirectURL": "https://YOUR_CLOUDFLARE_USER_NAME.cloudflareaccess.com/cdn-cgi/access/callback",
+  "serversToCheckRolesFor": ["YOUR_DISCORD_SERVER_ID"]
+}
+```
+
+- Replace `YOUR_DISCORD_CLIENT_ID` with the actual discord client id
+- Replace `YOUR_DISCORD_CLIENT_SECRET` with the actual discord client secret
+- Replace `YOUR_CLOUDFLARE_USER_NAME` with the actual cloudflare username
+- Replace `YOUR_DISCORD_SERVER_ID` with the Discord server that contains users who can access the web site (you can register multiple)
+
+Finally, deploy it.
+
+```sh
+npx wrangler publish
+```
+
+If your wrangler version is new, run the following.
+
+```sh
+npx wrangler deploy
+```
+
+### 3. Configure Cloudflare Zero Trust
+
+Register the Cloudflare Workers you just set up as an authentication provider in Cloudflare Zero Trust.
+
+Go to “Authentication” under “Settings”, click “Add New” in the “Login Methods” section, and move to the “Add OpenID Connect” page.
+
+![Login Methods section. There is “Add New” in the upper right](https://cdn.sh1ma.dev/e7593de96bfacde6ff31f37b754d1a3a798e4487259c50ca3fc4a8a3e3d5b6c8.png)
+
+![Form on the Add OpenID Connect page](https://cdn.sh1ma.dev/cb3a61f1c721045dcf8c76ed4d8cf859496be2d7ca6a07e91c63f516973874ac.png)
+
+Fill in the form items as follows.
+
+- Name: Anything. Set whatever name you like
+- App ID: Discord Client ID
+- Client secret: Discord Client secret
+- Auth URL: `https://discord-oidc.YOUR_CLOUDFLARE_USER_NAME.workers.dev/authorize/guilds`
+- Token URL: `https://discord-oidc.YOUR_CLOUDFLARE_USER_NAME.workers.dev/token`
+- Certificate URL: `https://discord-oidc.YOUR_CLOUDFLARE_USER_NAME.workers.dev/jwks.json`
+- Proof Key for Code Exchange (PKCE): Turn on
+- Email claim: No input required
+
+Configure OIDC Claims as follows.
+
+- id
+- username
+- discriminator
+- guilds
+
+![OIDC Claims configuration example](https://cdn.sh1ma.dev/7d03223d6f859dfcb3b1d89d71c735c18a88e9a75a7bd3d40ba5b1018b0a4ece.png)
+
+After filling in the above, it is good to press “Test” and actually try it. If it looks good, press “Save” and save it.
+
+### 4. Configure Cloudflare Access
+
+Configure Cloudflare Access to use the authentication created in step 3.  
+Go to the Cloudflare Access page and create an app with the “Add an application” button.
+
+![Cloudflare Access settings page. There is an “Add an apllication” button in the center](https://cdn.sh1ma.dev/28a085caedc57bf6b75fd879a130773a66da4d201af43c8841f1984ecadfc6b4.png)
+
+Select “Self Hosted”.
+
+![Add an application page. Self Hosted is on the far right](https://cdn.sh1ma.dev/85ef9dea3e66b4d0245c3f132baf1073500f817b14d657bd11fa43f009188a03.png)
+
+In Application Configuration, set the domain of the app whose access you want to restrict.
+
+- Session Duration sets the period for which the session is valid
+
+Set Identity Providers to only OpenID Connect.
+
+![Identity Providers configuration. Only OpenID Connect is configured](https://cdn.sh1ma.dev/665058db0746c05deaffc0a738d50846403730c31656b3537a1f69348de830a4.png)
+
+Press “Next” and proceed to Policies configuration.
+
+Configure Rules.
+
+Add the following to Include:
+
+- Select OIDC Claims
+- Enter “guilds” in “Claim name”
+- Enter the Discord server ID in “Claim value”
+
+![Configure Rules](https://cdn.sh1ma.dev/a5c3d3707f376737b69927383efe607f4103c7de4351f447b4cd887850de1000.png)
+
+Press “Save Policy” to save, and the setup is complete. If you go to the target domain and see a screen like the following, it was successful. Try logging in and checking the behavior.
+
+![Screenshot when accessing the target domain. A form prompting login appears in the center](https://cdn.sh1ma.dev/6be3fe282e3223637453d12f4c0b002fd0d3cca0cc2d14a2ea2354782d1ed578.png)
+
+## Summary
+
+I’m glad it was easier than I expected. discord-oidc-worker can authenticate not only by server but also by the user themselves, so I may use that too at some point.

--- a/src/markdown/posts/en/20241222_self-made-airtag-using-openhaystack-and-esp32.md
+++ b/src/markdown/posts/en/20241222_self-made-airtag-using-openhaystack-and-esp32.md
@@ -1,0 +1,119 @@
+---
+title: Trying to Build a DIY AirTag with ESP32 and OpenHaystack
+publishedAt: "2024-12-22"
+---
+
+It has become a completely chilly season. Since I wear Uniqlo AIRism all year round, it is unbearably cold when I go outside. I should probably buy HEATTECH soon.
+
+This time I tried using OpenHayStack, an OSS project that lets you build a DIY AirTag by piggybacking on the “Find My network” used by Apple’s “Find My” app, so I’d like to introduce the steps and such.
+
+## What Is OpenHaystack?
+
+OpenHayStack is a technology/software that can turn devices that speak Bluetooth (BLE) into AirTags by piggybacking on Apple’s Find My network.  
+It seems to have been developed from the results of reverse engineering the Find My network and AirTag.
+
+[seemoo-lab/openhaystack: Build your own 'AirTags' 🏷 today! Framework for tracking personal Bluetooth devices via Apple's massive Find My network.](https://github.com/seemoo-lab/openhaystack?tab=readme-ov-file#what-is-openhaystack)
+
+## Actually Trying It
+
+### Note
+
+In reality, even if you use the release version and follow [the official README steps](https://github.com/seemoo-lab/openhaystack?tab=readme-ov-file#installation), it does not work properly. To solve that, this time I worked with the latest state from the main branch instead of the release version. Please note that depending on the latest state of the main branch, the steps in this article may not work.
+
+### Environment
+
+- MacOS 14(Sonoma)
+- XCode Version 15.1 (15C65)
+- ESP32-compatible board
+
+### 1. Build OpenHaystack with XCode
+
+You can download a built application from Github Releases, but that version is old rather than the current development version, so it cannot be used. Therefore, you need to build it yourself without using the release version. So this step is required.
+
+First, clone the Github repository.
+
+```sh
+git clone --depth 1 https://github.com/seemoo-lab/openhaystack.git
+```
+
+By adding `--depth 1`, you can download only the latest commit history, so it downloads quickly.
+
+Inside the repository directory, there is `OpenHaystack.xcodeproj` in the `OpenHaystack` directory, and opening this should start XCode.
+However, depending on the Xcode version, a phenomenon like the one in the following article may occur, and I think errors or warnings about missing libraries will appear.
+
+[About the Package.resolved Deletion Issue Occurring in Xcode 15.3/15.4 #Swift - Qiita](https://qiita.com/tichise/items/a6525272e326e7798f05)
+
+I encountered this error, but I solved it by running the following, deleting `OpenHaystack/OpenHaystack.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`, and reopening XCode.
+
+```sh
+rm OpenHaystack/OpenHaystack.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+```
+
+When the build completes, an application like this opens. (This is an already set-up screen, so accessories are already displayed, but in reality I think nothing will be displayed yet.)
+
+![](https://cdn.sh1ma.dev/7b6b6d8a1dd5b890880e18c41ab2485a030ca33543c3c30299f1ac2de942f6c0.png)
+
+### 2. Setting Up OpenHaystack
+
+**On MacOS 14 and later, following [the OpenHaystack README steps](https://github.com/seemoo-lab/openhaystack?tab=readme-ov-file#installation) does not work.**
+
+I’ll introduce the actual steps for MacOS 14 and later.
+
+After building and launching the OpenHaystack application from XCode, go to OpenHaystack settings. Open it from “Settings” under OpenHaystack in the status bar. Then a settings window opens with a text field for entering “Search Party Token”.
+
+![Settings screen with the Search Party Token text field](https://cdn.sh1ma.dev/d9fc785094aed36c3fe2fdc8ccd8960595067d5092b4691c16c5585fa608776f.png)
+
+Put the token here. The token is in Keychain. Open the Keychain app and search for the following string.
+
+```
+com.apple.account.DeviceLocator.search-party-token
+```
+
+You can copy it by right-clicking the item and selecting “Copy Password to Clipboard”.
+
+![Keychain app screen. It shows search results for the phrase com.apple.account.DeviceLocator.search-party-token. One item is found](https://cdn.sh1ma.dev/131e673d33e983c73440ed42e9556c2d513059be887bd535b46491856af130b7.png)
+
+After entering it in the field from earlier, the application-side setup is complete.
+
+### 3. Flash the OpenHaystack Firmware to the ESP32
+
+OpenHaystack officially provides ESP32 firmware. Firmware flashing can be done by following the official steps, but I’ll introduce it here too. ([Official instructions](https://github.com/seemoo-lab/openhaystack/tree/main/Firmware/ESP32))
+
+For flashing, use a tool called ESP-IDF. I think the following is a good reference for ESP-IDF setup steps. It is OK if the command `idf.py` becomes available.
+
+[Standard Toolchain Setup for Linux and macOS - ESP32 - — ESP-IDF Programming Guide v5.3.2 documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/get-started/linux-macos-setup.html)
+
+Create a device from the OpenHaystack app in advance. You can create one from the location marked with a red circle in the image.
+
+![OpenHaystack app screen. The + button in the navigation bar is circled in red](https://cdn.sh1ma.dev/128c5211dfc9d313ea1d331c388fb4008425959049fcf191138a056efa1927b9.png)
+
+The device is added to the list, so right-click the added device and use “Copy advertisement key　→ Base64” to copy the advertising key in Base64 format.
+
+Enter the OpenHaystack project directory and move to `Firmware/ESP32`.
+
+```sh
+cd Firmware/ESP32
+```
+
+First, build the firmware.
+
+```sh
+idf.py build
+```
+
+Use `flash_esp32.sh` in the directory to flash it. Replace the “Base64-encoded advertisement key” part with the advertising key you copied earlier.
+
+```sh
+chmod +x flash_esp32.sh
+./flash_esp32.sh -p /dev/yourSerialPort "Base64-encoded advertisement key"
+```
+
+That completes setup. After a while, the device’s location should be displayed on the OpenHaystack screen. (If you press the refresh button in the upper right of the app, the location information should appear.) It felt like there was about a 5-minute lag from flashing the firmware until it appeared.
+
+## Summary
+
+I introduced how to run OpenHaystack using ESP32. I feel like I did this about two or three weeks ago already, so I wrote the article from vague memory. Sorry if there are any incorrect parts......
+
+Recently I also got OpenHaystack running using hardware called nRF52832, so I hope I can write an article about that too.
+
+Before I knew it, the new year had started.

--- a/src/markdown/posts/en/20250103_self-made-airtag-using-openhaystack-and-nrf52382.md
+++ b/src/markdown/posts/en/20250103_self-made-airtag-using-openhaystack-and-nrf52382.md
@@ -1,0 +1,141 @@
+---
+title: Making a Fake AirTag with nRF52832
+publishedAt: "2025-01-03"
+---
+
+Happy New Year!  
+This is my second OpenHaystack article. I was able to obtain a board with an nRF52832 on it, so I decided to turn this into a fake AirTag too.  
+This time it is a memo for myself.  
+(I’ll write a New Year’s article separately.)
+
+The nRF52832 device I procured this time was not something like a Dev Kit that can connect to a serial port over USB; at most, it was the kind of thing that can communicate over UART and SWD. So as the programmer, I used a Raspberry Pi 4 with OpenOCD installed and wrote the firmware over SWD.
+
+## Things Used This Time
+
+- Raspberry Pi 4 Model B
+- Jumper wires (as many as needed)
+- nRF52832
+
+## What to Do
+
+### Preparing OpenOCD
+
+Installing OpenOCD on a Raspberry Pi (running Raspberry OS) is very easy.  
+You can install it with the following command.
+
+```sh
+sudo apt install -y openocd
+```
+
+To communicate with hardware from the Raspberry Pi using SWD, use GPIO pins 24 and 25.  
+It is convenient to check the pin layout from the following.
+
+[Raspberry Pi GPIO Pinout](https://pinout.xyz/)
+
+- Pin 24: IO
+- Pin 25: CLK
+
+That’s it.
+
+After connecting the Raspberry Pi and the board nicely with jumper wires, write the configuration file.
+
+The following is the OpenOCD configuration for people using nRF523832, Raspberry Pi 4, and SWD.
+
+```txt
+adapter driver bcm2835gpio
+bcm2835gpio peripheral_base 0xFE000000
+
+bcm2835gpio speed_coeffs 236181 60
+
+adapter gpio swclk 25
+adapter gpio swdio 24
+
+transport select swd
+
+set CHIPNAME nrf52832
+source [find target/nrf52.cfg]
+
+nrf5 mass_erase
+
+init
+targets
+reset
+```
+
+The configuration file I referenced was in the article below, but it had old descriptions and I could not find descriptions for supporting Raspberry Pi 4, so I added and modified it.
+
+[Using Raspberry Pi as SWD programmer via OpenOCD Bitbang protocol — Ayan Pahwa](https://codensolder.com/blog/rip-swd-programmer)
+
+Save the above with a name such as `openhaystack.cfg`, and if running the following starts a telnet server, gdb server, and so on, the preparation is complete for now.
+
+```sh
+openocd -f openhaystack.cfg
+```
+
+### Preparing the nRF52832 Firmware
+
+I can build the firmware from scratch myself, but the easiest way is to flash a precompiled binary.  
+This time I’ll use firmware from a repository called macless-haystack. (Only the firmware is used.)
+
+[dchristl/macless-haystack: Create your own AirTag with OpenHaystack, but without the need to own an Apple device](https://github.com/dchristl/macless-haystack)
+
+Download the firmware with the following command. (Change the `v2.2.0` part as appropriate.)
+
+```sh
+wget https://github.com/dchristl/macless-haystack/releases/download/v2.2.0/nrf52_firmware.bin
+```
+
+Download generate_keys.py too, because it is used to create key information.
+
+```
+wget https://raw.githubusercontent.com/dchristl/macless-haystack/refs/heads/main/generate_keys.py
+```
+
+When you run generate_keys.py, key information files are created in `output/`.
+
+```sh
+python generate_keys.py
+```
+
+```
+❯ ls output
+ZDOU6E.keys  ZDOU6E_devices.json  ZDOU6E_keyfile
+```
+
+The `XXXXXX_keyfile` under `output/` is the advertising key. Embed this into the firmware.  
+[The steps are written in the official README](https://github.com/dchristl/macless-haystack/blob/main/firmware/nrf5x/README.md), but I’ll introduce them here too.
+
+Running the following embeds it.
+
+```sh
+export LC_CTYPE=C
+xxd -p -c 100000 XXXXXX_keyfile | xxd -r -p | dd of=nrf51_firmware.bin skip=1 bs=1 seek=$(grep -oba OFFLINEFINDINGPUBLICKEYHERE! nrf51_firmware.bin | cut -d ':' -f 1) conv=notrunc
+```
+
+Once this much is done, the firmware preparation is complete.
+
+### Flashing the Firmware to the nRF52832
+
+Add the following to the OpenOCD configuration file created in the “Preparing OpenOCD” section.
+
+Note: Do not forget `nrf5 mass_erase`. This is a command that disables write protection called Readback Protection. If you forget it, the firmware cannot be written and it fails with an error.
+
+```txt
+nrf5 mass_erase
+program nrf52_firmware2.bin verify
+reset
+```
+
+After adding it, run the following.
+
+```sh
+openocd -f openhaystack.cfg
+```
+
+If the firmware is written correctly, I think the device will become online in the OpenHaystack app within a few minutes.
+
+## Summary
+
+In reality I struggled a lot, but I’m omitting quite a bit here.  
+Recently I’ve been enjoying tinkering with microcontrollers and hardware. If I find another interesting toy, I’ll introduce it.
+See you!

--- a/src/markdown/posts/en/20250510_toughpad-fz-g1-buttons-doesnt-work-on-mobian.md
+++ b/src/markdown/posts/en/20250510_toughpad-fz-g1-buttons-doesnt-work-on-mobian.md
@@ -1,0 +1,472 @@
+---
+title: Making the TOUGHPAD A1/A2 Buttons Work on Mobian (Debian)
+publishedAt: "2025-05-10"
+---
+
+It’s been a while.  
+I had been neglecting blog updates for a long time. It’s not that I don’t have topics, but because I write slowly, it became a pain to write, and there are several shelved articles.... Recently I realized that apparently I can’t add to something I left half-written a month later. Myself from a month ago is basically another person, after all. From this month, I’d like to post about once a month. That’s the feeling.
+
+Now then, the other day I got a junk TOUGHPAD (model number: FZ-G1) from a friend in Akiba. At the time of purchase, it had been initialized and had no OS installed, so I decided to install Debian with [Phosh](https://phosh.mobi/) (a GUI environment for smartphones) integrated into it: [Mobian](https://mobian-project.org/). (It seems several TOUGHPAD units were bought among friends, and some people installed Arch Linux and used [Plasma Mobile](https://plasma-mobile.org/ja/) for the GUI.)
+
+![Mobian splash screen](https://p.ipic.vip/z8sc26.jpeg)
+
+![Mobian passcode input screen](https://p.ipic.vip/dhbwj2.jpeg)
+
+When I set `Scale` to `200%` from `Displays` in settings, it looked much better.
+
+![Mobian Displays settings. Scale is set to 200%](https://p.ipic.vip/q2ul6u.jpeg)
+
+![Mobian home screen](https://p.ipic.vip/6csxup.jpeg)
+
+After installing Mobian, I was excited for a while that browser video playback, Discord, and other software worked, but after touching it for a while I noticed something. The A1 button and A2 button did not work. Strictly speaking, among the physical buttons, only the A1 and A2 buttons did not work. All of the friends who bought TOUGHPADs also faced this issue where the A1/A2 buttons did not work.
+
+At this point I could have ended with “Oh. They don’t work.” But I was intrigued by the phenomenon where “the other buttons work perfectly, but only the A1/A2 buttons do not work,” so I decided to investigate with the goal of “taking screenshots with the A1/A2 buttons.”
+
+## Investigation
+
+### Check Whether the Input Is Recognized by the OS
+
+First, I thought I needed to identify which device the input was coming from, so I tried analyzing it with the `evtest` command. Below is the output when running the `evtest` command without arguments.
+
+```
+mobian@mobian:~$ evtest
+No device specified, trying to scan all of /dev/input/event*
+Not running as root, no devices may be available.
+Available devices:
+/dev/input/event0:	AT Translated Set 2 keyboard
+/dev/input/event1:	SEM USB Keyboard
+/dev/input/event10:	Power Button
+/dev/input/event11:	Power Button
+/dev/input/event12:	Panasonic Laptop Support
+/dev/input/event13:	Intel Virtual Buttons
+/dev/input/event14:	HDA Intel HDMI HDMI/DP,pcm=7
+/dev/input/event15:	HDA Intel HDMI HDMI/DP,pcm=8
+/dev/input/event16:	HDA Intel PCH Headphone
+/dev/input/event2:	eGalax Inc. eGalaxTouch EXC3000-0077-22.00.00
+/dev/input/event3:	eGalax Inc. eGalaxTouch EXC3000-0077-22.00.00 UNKNOWN
+/dev/input/event4:	SEM USB Keyboard Consumer Control
+/dev/input/event5:	SEM USB Keyboard System Control
+/dev/input/event6:	Wacom ISDv4 EC Pen
+/dev/input/event7:	PC Speaker
+/dev/input/event8:	HDA Intel HDMI HDMI/DP,pcm=3
+/dev/input/event9:	Video Bus
+Select the device event number [0-16]:
+```
+
+After making guesses and checking several event devices, I learned the following.
+
+- `/dev/input/event11` fires an event when the power button is pressed
+- `/dev/input/event12` fires when the volume down and volume up buttons are pressed
+- `/dev/input/event13` fires when the Windows button and screen rotation button are pressed
+
+However, none of the event files fired when the A1/A2 buttons were pressed. I also tried using `libinput debug-events` and `acpi_listen`, but those did not react either.
+
+While I was looking into ways to capture input events, a friend shared the following blog with me.
+
+[FZ-G1-Mk3 | Wade Mealing](https://wmealing.github.io/toughpad-fz-g1-buttons-acpi.html?utm_source=chatgpt.com)
+
+The discussion in this blog, based on almost the same situation of “the A1/A2 buttons do not work on Linux installed on an FZ-G1,” was very useful to me.
+
+To summarize, the blog said the following.
+
+- The A1/A2 buttons do not react in `libinput debug-events` ← same as me
+- There is an implementation close to this in [KaarelP2rtel/panasonic-hbtn: Panasonic Toughpad FZ-M1 Tablet Button driver for Linux](https://github.com/KaarelP2rtel/panasonic-hbtn). ← This suggests these buttons operate via ACPI
+- Enabling `CONFIG_ACPI_DEBUG=y` in the Linux kernel makes the ACPI debug log feature available. When ACPI debug logging is enabled, kernel logs flow when A1/A2 buttons fire (can be checked with `dmesg`)
+- Based on the kernel logs that appeared, the author checked the ACPI table, guessed that `Device (HKEY)` was the source, and wrote a simple driver, but it had no effect
+
+Of these, “when ACPI debug logging is enabled, kernel logs flow when the buttons are pressed” seemed worth trying, so I decided to try it.
+
+### Compiling and Installing the Linux Kernel
+
+I think there are other articles where people write the Linux kernel compilation steps in detail, so here I’ll briefly write what I did.
+Considering the specs, compiling the Linux kernel on the TOUGHPAD seemed like it would take quite a long time, so for compilation I prepared a separate x86_64 machine and did it there.
+
+#### 1. Prepare Linux Kernel Dependencies
+
+Dependencies can be prepared with the following command.
+
+```bash
+sudo apt build-dep linux
+```
+
+#### 2. Prepare the Linux Kernel Source Code
+
+The Linux kernel version on the TOUGHPAD was 6.12.25, so I downloaded linux-6.12.28.tar.xz.
+
+```
+curl -LO https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.12.28.tar.xz
+```
+
+It can be extracted with the following command.
+
+```
+tar -xf linux-6.12.25.tar.xz
+```
+
+#### 4. Prepare .config
+
+Settings for Linux kernel compilation are written in `.config`.  
+The earlier `CONFIG_ACPI_DEBUG=y` is also written here. Because there must not be differences from Mobian’s config, I brought Mobian’s config from the TOUGHPAD, edited the `CONFIG_ACPI_DEBUG` item to `y`, and placed it inside the Linux kernel source code directory under the name `.config`. (At this time I also enabled a few other things, but I forgot what they were.)
+
+```
+CONFIG_ACPI_DEBUG=y
+```
+
+The `.config` on my TOUGHPAD was located at `/boot/config-6.12.25`.
+
+**For the later work, if the following are not enabled, please enable them. If these are not enabled, you cannot override ACPI tables at boot time.**
+
+They were already enabled on Mobian on the TOUGHPAD, but just in case.
+
+```
+CONFIG_ARCH_HAS_ACPI_TABLE_UPGRADE=y
+CONFIG_ACPI_TABLE_UPGRADE=y
+```
+
+#### 5. Compile
+
+Run the following command and wait about 15 minutes. Depending on the specs of the machine doing the compilation, you may wait longer.  
+For reference: the CPU I used was `AMD Ryzen 5 7600X 6-Core Processor`.
+
+```
+make clean
+make -j$(nproc)
+```
+
+#### 6. Copy the Build Artifacts to the TOUGHPAD
+
+Since I would run `make install` and so on on the TOUGHPAD side, copy the entire compiled Linux kernel directory to the TOUGHPAD.
+
+The compiled Linux kernel directory is extremely heavy, so moving it was difficult, but when I configured rsync as follows, it finished in about 7 minutes.
+
+Edit `/etc/rsyncd.conf` on the machine used for compilation as follows.
+
+```
+uid         = root
+gid         = root
+log file    = /var/log/rsyncd.log
+pid file    = /var/run/rsyncd.pid
+
+[linux-kernel]
+path = /home/sh1ma/workspace/linux-6.12.25
+```
+
+Adjust `/home/sh1ma/workspace/linux-6.12.25` to match the directory where each person’s Linux kernel is located.
+
+Run the following on the machine used for compilation.
+
+```
+rsync --daemon
+```
+
+This starts rsyncd, making communication through the rsync protocol (TCP), rather than ssh, available.
+
+After that, run the following on the TOUGHPAD side, and files will be copied quickly.
+
+```
+rsync -azvh --info=progress2 --whole-file rsync://192.168.100.12/linux-kernel ~/workspace/
+```
+
+#### 7. Install the Build Artifacts
+
+Once the compiled Linux kernel directory has been copied, the work from here is on the TOUGHPAD side.
+
+Because many kernel modules are not actually needed, edit the setting in `/etc/initramfs-tools/initramfs.conf` so that only the necessary ones are installed.
+
+```
+MODULES=dep
+```
+
+Update initramfs.
+
+```
+sudo update-initramfs -u -k 6.12.25
+```
+
+Run the following.
+
+```
+sudo make modules_install
+sudo make install
+```
+
+With this, installation is complete! After rebooting, the new kernel should be applied.
+
+### Viewing ACPI Debug Logs
+
+When booting a Linux kernel configured with `CONFIG_ACPI_DEBUG=y` at compile time, files called `debug_level` and `debug_layer` had been added under `/sys/module/acpi/parameters`.
+
+```
+mobian@mobian:~$ ls /sys/module/acpi/parameters
+acpica_version    debug_layer  ec_busy_polling  ec_event_clearing  ec_max_queries  ec_polling_guard    immediate_undock   trace_debug_level  trace_state
+aml_debug_output  debug_level  ec_delay         ec_freeze_events   ec_no_wakeup    ec_storm_threshold  trace_debug_layer  trace_method_name
+```
+
+Rewrite these values so that ACPI debug logs are emitted.
+
+First, enter root with the following command. (You cannot write unless you are root, so become root first.)
+
+```
+sudo su
+```
+
+Inspect the `debug_level` parameter.
+
+```
+cat /sys/module/acpi/parameters/debug_level
+```
+
+Output ↓
+
+```
+Description              	Hex        SET
+ACPI_LV_INIT             	0x00000001 [ ]
+ACPI_LV_DEBUG_OBJECT     	0x00000002 [ ]
+ACPI_LV_INFO             	0x00000004 [ ]
+ACPI_LV_REPAIR           	0x00000008 [ ]
+ACPI_LV_TRACE_POINT      	0x00000010 [ ]
+ACPI_LV_INIT_NAMES       	0x00000020 [ ]
+ACPI_LV_PARSE            	0x00000040 [ ]
+ACPI_LV_LOAD             	0x00000080 [ ]
+ACPI_LV_DISPATCH         	0x00000100 [ ]
+ACPI_LV_EXEC             	0x00000200 [ ]
+ACPI_LV_NAMES            	0x00000400 [ ]
+ACPI_LV_OPREGION         	0x00000800 [ ]
+ACPI_LV_BFIELD           	0x00001000 [ ]
+ACPI_LV_TABLES           	0x00002000 [ ]
+ACPI_LV_VALUES           	0x00004000 [ ]
+ACPI_LV_OBJECTS          	0x00008000 [ ]
+ACPI_LV_RESOURCES        	0x00010000 [ ]
+ACPI_LV_USER_REQUESTS    	0x00020000 [ ]
+ACPI_LV_PACKAGE          	0x00040000 [ ]
+ACPI_LV_ALLOCATIONS      	0x00100000 [ ]
+ACPI_LV_FUNCTIONS        	0x00200000 [ ]
+ACPI_LV_OPTIMIZATIONS    	0x00400000 [ ]
+ACPI_LV_MUTEX            	0x01000000 [ ]
+ACPI_LV_THREADS          	0x02000000 [ ]
+ACPI_LV_IO               	0x04000000 [ ]
+ACPI_LV_INTERRUPTS       	0x08000000 [ ]
+ACPI_LV_AML_DISASSEMBLE  	0x10000000 [ ]
+ACPI_LV_VERBOSE_INFO     	0x20000000 [ ]
+ACPI_LV_FULL_TABLES      	0x40000000 [ ]
+ACPI_LV_EVENTS           	0x80000000 [ ]
+--
+debug_level = 0x00000000 (* = enabled)
+```
+
+Inspect the `debug_layer` parameter.
+
+```
+cat /sys/module/acpi/parameters/debug_layer
+```
+
+Output ↓
+
+```
+Description              	Hex        SET
+ACPI_UTILITIES           	0x00000001 [ ]
+ACPI_HARDWARE            	0x00000002 [ ]
+ACPI_EVENTS              	0x00000004 [ ]
+ACPI_TABLES              	0x00000008 [ ]
+ACPI_NAMESPACE           	0x00000010 [ ]
+ACPI_PARSER              	0x00000020 [ ]
+ACPI_DISPATCHER          	0x00000040 [ ]
+ACPI_EXECUTER            	0x00000080 [ ]
+ACPI_RESOURCES           	0x00000100 [ ]
+ACPI_CA_DEBUGGER         	0x00000200 [ ]
+ACPI_OS_SERVICES         	0x00000400 [ ]
+ACPI_CA_DISASSEMBLER     	0x00000800 [ ]
+ACPI_COMPILER            	0x00001000 [ ]
+ACPI_TOOLS               	0x00002000 [ ]
+ACPI_ALL_DRIVERS         	0xFFFF0000 [ ]
+--
+debug_layer = 0x00000000 ( * = enabled)
+```
+
+As settings for the logs that appear when the A1/A2 buttons are actually pressed, rewriting them as follows worked well.
+
+```
+echo 0x200 > /sys/module/acpi/parameters/debug_level
+echo 0x82 > /sys/module/acpi/parameters/debug_layer
+```
+
+- Setting `debug_level` to `0x200` makes only `ACPI_LV_EXEC` enabled
+- Setting `debug_layer` to `0x82` makes `ACPI_HARDWARE` and `ACPI_EXECUTER` enabled
+
+If the above rewrite succeeds, debug logs are enabled. The settings are lost after rebooting.
+
+Check the debug logs. Debug logs appear as kernel logs, so they can be checked with `dmesg -w`.
+
+A large amount of logs flow, but running a command like the following should make them flow at an understandable speed.
+
+[Wade Mealing](https://wmealing.github.io/toughpad-fz-g1-buttons-acpi.html?utm_source=chatgpt.com#enabling-acpi-events)
+
+>
+
+```bash
+dmesg -w | grep Notify -A5 -B5
+```
+
+The logs to focus on are around Notify, like the following. No matter how many times either the A1 or A2 button is pressed, this log always appears. This is probably safe to treat as the log from pressing the A1/A2 buttons. In particular, `TBTN` in the log looks like a symbol from the DSDT in the ACPI table.
+
+```
+[31002.859886]   exresop-0126 ex_resolve_operands   : Opcode 86 [Notify] RequiredOperandTypes=000001A6
+[31002.859890]  exresolv-0084 ex_resolve_to_value   : Resolved object 00000000c7a02e9c
+[31002.859892]    exdump-0880 ex_dump_operands      : **** Start operand dump for opcode [Notify], 2 operands
+[31002.859895]    exdump-0603 ex_dump_operand       : 000000009e1948ee Namespace Node:  0  TBTN Device       000000009e1948ee 001 Notify Object: 00000000dfc93cab
+```
+
+### Decompiling the ACPI Table
+
+Let’s organize the situation so far.
+
+- Button press events were not output by input analysis tools such as `libinput debug-events`, `evtest`, and `acpi_listen`
+  - From this, the following became clear
+    - Input events are not being reported to the [Linux Input SubSystem](https://docs.kernel.org/input/input_uapi.html)
+    - ACPI notifications are not reaching userland from the Linux kernel
+- Button presses could be detected in Linux kernel logs (`dmesg -w`)
+
+From the above, I learned that “ACPI events are being ignored by the Linux kernel, or are being swallowed.”
+
+So next, as in the operations in the [FZ-G1-Mk3 | Wade Mealing](https://wmealing.github.io/toughpad-fz-g1-buttons-acpi.html?utm_source=chatgpt.com#acpi-tables) blog, dump the ACPI table and decompile the DSDT. Then investigate the definition of `TBTN` found earlier. The work of decompiling → overriding DSDT is written in more detail on the following page.
+
+[DSDT - ArchWiki](https://wiki.archlinux.jp/index.php/DSDT)
+
+First, install `acpica-tool`, a tool for investigation.
+
+```bash
+sudo apt install acpica-tool
+```
+
+Dump the ACPI table with the `acpidump` command. (Multiple files will be generated in the current directory, so I recommend doing this in a working directory.)
+
+```bash
+sudo acpidump -b
+```
+
+After running it, dumped ACPI binary files are output in the current directory.
+
+```
+mobian@mobian:~/tmp$ ls
+ apic.dat    dsdt.dat   hpet.dat   pcct.dat     ssdt12.dat   ssdt2.dat   ssdt6.dat   tcpa.dat
+'asf!.dat'   facp.dat   lpit.dat   slic.dat     ssdt13.dat   ssdt3.dat   ssdt7.dat
+ bgrt.dat    facs.dat   mcfg.dat   ssdt10.dat   ssdt14.dat   ssdt4.dat   ssdt8.dat
+ dmar.dat    fpdt.dat   msdm.dat   ssdt11.dat   ssdt1.dat    ssdt5.dat   ssdt9.dat
+```
+
+Of these, only dsdt.dat is used.
+The following command generates `dsdt.dsl`, a decompiled file from `dsdt.dat`.
+
+```bash
+iasl -d dsdt.dat
+```
+
+I saved the generated `dsdt.dsl` in the following gist.  
+[TOUGHPAD FZ-G1 ACPI DSDT Table](https://gist.github.com/sh1ma/2c44b2da7445de88fdc1b599d3159da8)
+
+I’ll investigate `TBTN` from `dsdt.dsl`.  
+Searching for `TBTN` reveals a section like the following.
+
+```
+    Scope (\_SB)
+    {
+        Device (TBTN)
+        {
+            Mutex (HDMX, 0x00)
+            Method (_HID, 0, NotSerialized)  // _HID: Hardware ID
+            {
+                If ((\_SB.PCI0.LPCB.GSGP (0x10, 0x01) == 0x01))
+                {
+                    If ((\_SB.PCI0.LPCB.GSGP (0x16, 0x01) != \_SB.PCI0.LPCB.GSGP (0x17, 0x01)))
+                    {
+                        Return (0x2B003434)
+                    }
+                }
+
+                Return (0x2A003434)
+            }
+```
+
+[Relevant section in the gist](https://gist.github.com/sh1ma/2c44b2da7445de88fdc1b599d3159da8#file-dsdt-dsl-L18182-L18198)
+
+Several methods are tied to `Device (TBTN)`.
+Among them, `_HID` is a reference that returns a hardware-specific ID.
+
+According to section 6.1.5 of the [latest ACPI Spec](https://uefi.org/sites/default/files/resources/ACPI_Spec_6.5a_Final.pdf), `_HID` is described as follows.
+
+> 6.1.5 \_HID (Hardware ID)
+>
+> This object is used to supply OSPM with the device’s PNP ID or ACPI ID.  
+> (Japanese translation: This object is used to provide the device’s PNP ID or ACPI ID to OSPM.)
+> ）
+
+OSPM is an abbreviation for “Operating System-directed configuration and Power Management,” and it should be fine to rephrase it as ACPI. In other words, it is reasonable to understand it as a method that tells the OS the HID.
+
+I understood that much, but what bothered me was that it looked different from other HIDs. Specifically, the following two points differ.
+
+- Other HIDs in `dsdt.dsl` are in a format like `Name (_HID, EisaId ("PNP0C02")`. This is defined as a constant function where `EisaId ("PNP0C02")` is always returned when the `_HID` method is invoked, whereas the `_HID` method of `TBTN` has conditional branching.
+- Other `_HID`s return strings wrapped in `EisaId()`, whereas `TBTN`’s `_HID` returns primitive numbers.
+
+I wondered whether `_HID` also permits numeric types, so I continued reading the ACPI Spec and learned the following.
+
+- `EisaId()` is a macro that converts a string EISA ID to a numeric type
+  - It was mentioned in _19.6.37 EISAID (EISA ID String To Integer Conversion Macro)_ of the [ACPI Spec](https://uefi.org/sites/default/files/resources/ACPI_Spec_6.5a_Final.pdf)
+- The return value of `_HID` is either a string or a number
+  - If it is a string, it is a PNP ID or ACPI ID composed of alphanumeric characters
+    - PNP ID and ACPI ID are described in detail in [PNP ID and ACPI ID Registry | Unified Extensible Firmware Interface Forum](https://uefi.org/PNP_ACPI_Registry)
+  - If it is numeric, it is a 32-bit compressed EISA type ID
+    - This number can be converted to a string HID. In _19.3.4 ASL Macros_ of the [ACPI Spec](https://uefi.org/sites/default/files/resources/ACPI_Spec_6.5a_Final.pdf), it is mentioned as follows
+      > Converts and compresses the 7-character text argument into its corresponding 4-byte numeric EISA ID encoding (Integer). This can be used when declaring IDs for devices that are EISA IDs.
+    - It also introduced the procedure for converting from a 32-bit compressed EISA type ID to a string
+
+At this point I knew that the return value of `TBTN`’s `_HID` is a 32-bit compressed EISA type ID, so I wrote a script to decode the two return values from `TBTN`’s `_HID` above.
+
+```python
+def decode_eisa_id(eisa_id: int):
+    eisa_id = int.from_bytes(eisa_id.to_bytes(4, "little"), "big")
+    vendor = ""
+    vendor_bits = (eisa_id >> 16) & 0xFFFF
+
+    char1_val = (vendor_bits >> 10) & 0x1F
+    char2_val = (vendor_bits >> 5) & 0x1F
+    char3_val = vendor_bits & 0x1F
+
+    vendor += chr(char1_val + 0x40)
+    vendor += chr(char2_val + 0x40)
+    vendor += chr(char3_val + 0x40)
+
+    product_id = eisa_id & 0xFFFF
+    return f"{vendor}{product_id:04X}"
+
+
+id1 = 0x2A003434
+id2 = 0x2B003434
+
+print(f"0x{id1:08X} -> {decode_eisa_id(id1)}")
+print(f"0x{id2:08X} -> {decode_eisa_id(id2)}")
+```
+
+[gist](https://gist.github.com/sh1ma/e106e4503e9bbb1bcc1dbc151e9bc202)
+
+The output was as follows.
+
+```
+❯ python decode.py
+0x2A003434 -> MAT002A
+0x2B003434 -> MAT002B
+```
+
+I looked at the HIDs of several other defined devices, and there were several with the prefix `MAT`. Therefore the decoded result seems correct.
+
+Once the HID is known, the rest is the work of writing a driver.
+
+I’ll put the resulting work below.
+
+[sh1ma/tbtn-driver: TOUGPAD TBTN (A1, A2 buttons) Linux kernel driver](https://github.com/sh1ma/tbtn-driver)
+
+[You can watch a video of the A1/A2 buttons working here](https://cdn.sh1ma.dev/IMG_1051.mp4)
+
+## Summary
+
+Before writing the real driver, I actually rewrote the DSDT `TBTN` HID to the fixed value `PNP0C40`, overrode the ACPI table, wrote a driver for that, and got it working, but I omitted that from the article. (Writing it became a pain.)  
+I’d like to write another article as a memo about how to override DSDT and such.

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { ExternalLink, Github, Sparkles } from "lucide-react"
-import { TranslationNotice } from "@/components/TranslationNotice/TranslationNotice"
 
 export const Route = createFileRoute("/about")({
   component: AboutPage,
@@ -93,8 +92,6 @@ const projects = [
 function AboutPage() {
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-8">
-      <TranslationNotice targetLocale="en" href="/en/about" />
-
       <section className="mb-12 rounded-2xl bg-bg-surface p-8 shadow-soft">
         <div className="mb-6 flex flex-col items-start gap-5 sm:flex-row sm:items-center">
           <img

--- a/src/routes/articles.$slug.tsx
+++ b/src/routes/articles.$slug.tsx
@@ -63,7 +63,7 @@ function ArticlePage() {
       </header>
 
       {hasEnglishVersion && (
-        <TranslationNotice targetLocale="en" href={`/articles/en/${post.id}`} />
+        <TranslationNotice targetLocale="en" href={`/en/articles/${post.id}`} />
       )}
 
       <TableOfContents headings={headings} initialOpen={false} />

--- a/src/routes/articles.en.$slug.tsx
+++ b/src/routes/articles.en.$slug.tsx
@@ -8,34 +8,34 @@ import { Tag } from "@/components/Tag/Tag"
 import { TranslationNotice } from "@/components/TranslationNotice/TranslationNotice"
 import { extractHeadings } from "@/utils/extractHeadings"
 
-export const Route = createFileRoute("/articles/$slug")({
-  component: ArticlePage,
+export const Route = createFileRoute("/articles/en/$slug")({
+  component: EnglishArticlePage,
   loader: ({ params }) => {
     const post = allArticles.find(
-      (p) => p.id === params.slug && p.locale === "ja",
-    )
-    if (!post) throw notFound()
-    const hasEnglishVersion = allArticles.some(
       (p) => p.id === params.slug && p.locale === "en",
     )
-    return { post, hasEnglishVersion }
+    if (!post) throw notFound()
+    const hasJapaneseVersion = allArticles.some(
+      (p) => p.id === params.slug && p.locale === "ja",
+    )
+    return { post, hasJapaneseVersion }
   },
   head: ({ loaderData }) => ({
     meta: loaderData
       ? [
           { title: loaderData.post.title },
-          { name: "description", content: "ブログ記事" },
+          { name: "description", content: "Blog article (English)" },
         ]
       : [{ title: "404" }],
   }),
 })
 
-function ArticlePage() {
-  const { post, hasEnglishVersion } = Route.useLoaderData()
+function EnglishArticlePage() {
+  const { post, hasJapaneseVersion } = Route.useLoaderData()
   const headings = extractHeadings(post.body.html)
 
   return (
-    <article className="mx-auto w-full max-w-3xl px-4 py-8">
+    <article className="mx-auto w-full max-w-3xl px-4 py-8" lang="en">
       <header className="mb-10 border-b border-gray-200 pb-6">
         {post.tags && post.tags.length > 0 && (
           <div className="mb-4 flex gap-2">
@@ -57,13 +57,13 @@ function ArticlePage() {
           <span className="size-1 rounded-full bg-gray-300" />
           <span className="flex items-center gap-1">
             <Clock size={16} />
-            {post.readingTime}分
+            {post.readingTime} min
           </span>
         </div>
       </header>
 
-      {hasEnglishVersion && (
-        <TranslationNotice targetLocale="en" href={`/articles/en/${post.id}`} />
+      {hasJapaneseVersion && (
+        <TranslationNotice targetLocale="ja" href={`/articles/${post.id}`} />
       )}
 
       <TableOfContents headings={headings} initialOpen={false} />

--- a/src/routes/en.about.tsx
+++ b/src/routes/en.about.tsx
@@ -2,12 +2,12 @@ import { createFileRoute } from "@tanstack/react-router"
 import { ExternalLink, Github, Sparkles } from "lucide-react"
 import { TranslationNotice } from "@/components/TranslationNotice/TranslationNotice"
 
-export const Route = createFileRoute("/about")({
-  component: AboutPage,
+export const Route = createFileRoute("/en/about")({
+  component: EnglishAboutPage,
   head: () => ({
     meta: [
       { title: "About - blog.sh1ma.dev" },
-      { name: "description", content: "sh1ma について" },
+      { name: "description", content: "About sh1ma" },
     ],
   }),
 })
@@ -24,41 +24,41 @@ const languages: Language[] = [
     name: "Python",
     level: 5,
     liking: "love",
-    note: "一番得意な言語。書き慣れていて、使えるから好き。",
+    note: "My strongest language. I'm used to writing it and comfortable with it, and I like that I can actually use it.",
   },
   {
     name: "Rust",
     level: 4,
     liking: "love",
-    note: "仕事で書いている。かなり使い心地がいいので好きになりそう。",
+    note: "I write it at work. It feels really nice to use, so I might come to love it.",
   },
   {
     name: "TypeScript",
     level: 4,
     liking: "like",
-    note: "仕事でもこのブログでも使っている。Python ほどではないけれど好きな部類。",
+    note: "I use it both at work and on this blog. Not quite as much as Python, but I do like it.",
   },
   {
     name: "Go",
     level: 3,
     liking: "dislike",
-    note: "仕事で使ったことがある。あんまり好きじゃない。",
+    note: "I've used it at work. Not really my favorite.",
   },
 ]
 
 const hobbies = [
   {
-    title: "読書",
+    title: "Reading",
     items: [
-      "小説が好き。最近はあまり読めていない。",
-      "最近は専ら技術書ばかり読んでいる。",
+      "I like novels. I haven't been reading many lately.",
+      "These days I mostly read technical books.",
     ],
   },
   {
-    title: "ニコニコ動画",
+    title: "Niconico Douga",
     items: [
-      "毎日見ている。",
-      "合成音声キャラが喋る動画、特に「ソフトウェアトーク劇場」タグをよく見る。",
+      "I watch it every day.",
+      'I mostly watch videos with synthetic-voice characters — especially the "Software Talk Theater" tag.',
     ],
   },
 ]
@@ -68,38 +68,37 @@ const projects = [
     name: "sh1ma/pyne",
     tagline: "LINE for Python",
     description:
-      "LINE の API を Python から扱うためのライブラリ。現在はアーカイブ済み。",
+      "A library for using the LINE API from Python. Currently archived.",
     href: "https://github.com/sh1ma/pyne",
     archived: true,
   },
   {
     name: "sh1ma/voicevoxcore.go",
-    tagline: "VOICEVOX Core の Go ラッパー",
-    description:
-      "voicevox_core を Go から呼び出すためのラッパー。FFI を利用している。",
+    tagline: "Go wrapper for VOICEVOX Core",
+    description: "A wrapper that calls voicevox_core from Go, using FFI.",
     href: "https://github.com/sh1ma/voicevoxcore.go",
     archived: false,
   },
   {
     name: "sh1ma/iostrace",
-    tagline: "frida ベースの iOS 用 strace 代替",
+    tagline: "A frida-based strace alternative for iOS",
     description:
-      "64bit iOS デバイス向けの strace 相当を frida で実現するツール。",
+      "A tool that provides strace-equivalent functionality for 64-bit iOS devices using frida.",
     href: "https://github.com/sh1ma/iostrace",
     archived: false,
   },
 ]
 
-function AboutPage() {
+function EnglishAboutPage() {
   return (
-    <main className="mx-auto w-full max-w-3xl px-4 py-8">
-      <TranslationNotice targetLocale="en" href="/en/about" />
+    <main className="mx-auto w-full max-w-3xl px-4 py-8" lang="en">
+      <TranslationNotice targetLocale="ja" href="/about" />
 
       <section className="mb-12 rounded-2xl bg-bg-surface p-8 shadow-soft">
         <div className="mb-6 flex flex-col items-start gap-5 sm:flex-row sm:items-center">
           <img
             src="/anon-illust.jpeg"
-            alt="sh1ma のアイコン"
+            alt="sh1ma's icon"
             width={96}
             height={96}
             className="size-24 shrink-0 rounded-full object-cover shadow-soft ring-2 ring-brand-primary-light/40"
@@ -115,16 +114,17 @@ function AboutPage() {
           </div>
         </div>
         <p className="mb-6 text-lg leading-relaxed text-text-secondary">
-          エンジニアをしています。普段はサーバーサイドや低レイヤ寄りのことを触ることが多いです。
+          I'm a software engineer. I usually work on server-side and low-level
+          things.
         </p>
         <dl className="flex flex-wrap gap-x-8 gap-y-3 border-t border-border-subtle pt-6 text-sm">
           <div className="flex items-center gap-2">
-            <dt className="text-text-muted">生まれ</dt>
-            <dd className="font-medium text-text-primary">2000 年</dd>
+            <dt className="text-text-muted">Born</dt>
+            <dd className="font-medium text-text-primary">2000</dd>
           </div>
           <div className="flex items-center gap-2">
-            <dt className="text-text-muted">職業</dt>
-            <dd className="font-medium text-text-primary">エンジニア</dd>
+            <dt className="text-text-muted">Occupation</dt>
+            <dd className="font-medium text-text-primary">Engineer</dd>
           </div>
           <div className="flex items-center gap-2">
             <dt className="text-text-muted">GitHub</dt>
@@ -143,7 +143,7 @@ function AboutPage() {
         </dl>
       </section>
 
-      <Section title="Skills" subtitle="よく使うプログラミング言語">
+      <Section title="Skills" subtitle="Programming languages I often use">
         <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {languages.map((lang) => (
             <LanguageCard key={lang.name} language={lang} />
@@ -151,7 +151,7 @@ function AboutPage() {
         </ul>
       </Section>
 
-      <Section title="Hobbies" subtitle="趣味">
+      <Section title="Hobbies" subtitle="What I enjoy">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {hobbies.map((hobby) => (
             <div
@@ -177,7 +177,7 @@ function AboutPage() {
         </div>
       </Section>
 
-      <Section title="Projects" subtitle="作ったもの">
+      <Section title="Projects" subtitle="Things I've built">
         <ul className="flex flex-col gap-4">
           {projects.map((project) => (
             <li key={project.name}>
@@ -241,10 +241,10 @@ function Section({
 }
 
 const likingLabel: Record<Language["liking"], string> = {
-  love: "好き",
-  like: "好き",
-  neutral: "普通",
-  dislike: "そんなに",
+  love: "Love",
+  like: "Like",
+  neutral: "Neutral",
+  dislike: "Not really",
 }
 
 const likingClass: Record<Language["liking"], string> = {
@@ -275,7 +275,7 @@ function LanguageCard({ language }: { language: Language }) {
 
 function ProficiencyMeter({ level }: { level: Language["level"] }) {
   return (
-    <div className="flex gap-1" title={`習熟度 ${level} / 5`}>
+    <div className="flex gap-1" title={`Proficiency ${level} / 5`}>
       {[1, 2, 3, 4, 5].map((n) => (
         <span
           key={n}

--- a/src/routes/en.about.tsx
+++ b/src/routes/en.about.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { ExternalLink, Github, Sparkles } from "lucide-react"
-import { TranslationNotice } from "@/components/TranslationNotice/TranslationNotice"
 
 export const Route = createFileRoute("/en/about")({
   component: EnglishAboutPage,
@@ -92,8 +91,6 @@ const projects = [
 function EnglishAboutPage() {
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-8" lang="en">
-      <TranslationNotice targetLocale="ja" href="/about" />
-
       <section className="mb-12 rounded-2xl bg-bg-surface p-8 shadow-soft">
         <div className="mb-6 flex flex-col items-start gap-5 sm:flex-row sm:items-center">
           <img

--- a/src/routes/en.articles.$slug.tsx
+++ b/src/routes/en.articles.$slug.tsx
@@ -8,7 +8,7 @@ import { Tag } from "@/components/Tag/Tag"
 import { TranslationNotice } from "@/components/TranslationNotice/TranslationNotice"
 import { extractHeadings } from "@/utils/extractHeadings"
 
-export const Route = createFileRoute("/articles/en/$slug")({
+export const Route = createFileRoute("/en/articles/$slug")({
   component: EnglishArticlePage,
   loader: ({ params }) => {
     const post = allArticles.find(

--- a/src/routes/en.index.tsx
+++ b/src/routes/en.index.tsx
@@ -3,7 +3,6 @@ import { allArticles } from "contentlayer/generated"
 import dayjs from "dayjs"
 import { Calendar, Clock, ImageOff } from "lucide-react"
 import { Tag } from "@/components/Tag/Tag"
-import { TranslationNotice } from "@/components/TranslationNotice/TranslationNotice"
 
 export const Route = createFileRoute("/en/")({
   component: EnglishHomePage,
@@ -31,8 +30,6 @@ function EnglishHomePage() {
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-8" lang="en">
-      <TranslationNotice targetLocale="ja" href="/" />
-
       <div className="mb-12">
         <h2 className="mb-2 text-4xl font-bold tracking-tight text-text-primary">
           Latest Writings

--- a/src/routes/en.index.tsx
+++ b/src/routes/en.index.tsx
@@ -1,0 +1,125 @@
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { allArticles } from "contentlayer/generated"
+import dayjs from "dayjs"
+import { Calendar, Clock, ImageOff } from "lucide-react"
+import { Tag } from "@/components/Tag/Tag"
+import { TranslationNotice } from "@/components/TranslationNotice/TranslationNotice"
+
+export const Route = createFileRoute("/en/")({
+  component: EnglishHomePage,
+  head: () => ({
+    meta: [
+      { title: "blog.sh1ma.dev" },
+      { name: "description", content: "sh1ma's blog" },
+    ],
+  }),
+})
+
+function EnglishHomePage() {
+  const articles = allArticles
+    .filter((article) => article.locale === "en")
+    .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
+    .map((article) => ({
+      id: article.id,
+      title: article.title,
+      description: article.description,
+      thumbnail: article.thumbnail,
+      publishedAt: dayjs(article.publishedAt).format("YYYY-MM-DD"),
+      readingTime: article.readingTime,
+      tags: article.tags,
+    }))
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8" lang="en">
+      <TranslationNotice targetLocale="ja" href="/" />
+
+      <div className="mb-12">
+        <h2 className="mb-2 text-4xl font-bold tracking-tight text-text-primary">
+          Latest Writings
+        </h2>
+      </div>
+
+      <div className="flex flex-col gap-6">
+        {articles.map((article) => (
+          <EnglishArticleCard key={article.id} {...article} />
+        ))}
+      </div>
+    </main>
+  )
+}
+
+type EnglishArticleCardProps = {
+  id: string
+  title: string
+  description?: string
+  thumbnail?: string
+  publishedAt: string
+  readingTime: number
+  tags?: string[]
+}
+
+function EnglishArticleCard({
+  id,
+  title,
+  description,
+  thumbnail,
+  publishedAt,
+  readingTime,
+  tags,
+}: EnglishArticleCardProps) {
+  return (
+    <Link to="/en/articles/$slug" params={{ slug: id }}>
+      <article className="group flex items-center gap-4 rounded-xl bg-bg-surface p-4 shadow-soft transition-all hover:-translate-y-1 hover:shadow-hover">
+        <div className="size-24 shrink-0 overflow-hidden rounded-lg">
+          {thumbnail ? (
+            <img
+              src={thumbnail}
+              alt={title}
+              width={96}
+              height={96}
+              loading="lazy"
+              className="size-full object-cover transition-transform duration-300 group-hover:scale-105"
+            />
+          ) : (
+            <div className="flex size-full flex-col items-center justify-center bg-gray-100 text-gray-400">
+              <ImageOff size={24} />
+              <span className="mt-1 text-xs">No Image</span>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-1 flex-col gap-2">
+          {tags && tags.length > 0 && (
+            <div className="flex gap-2">
+              {tags.map((tag) => (
+                <Tag key={tag} label={tag} size="sm" />
+              ))}
+            </div>
+          )}
+
+          <h3 className="text-xl font-bold leading-tight text-brand-primary transition-colors group-hover:underline">
+            {title}
+          </h3>
+
+          {description && (
+            <p className="line-clamp-2 text-sm leading-snug text-text-secondary">
+              {description}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-3 text-sm text-text-muted">
+            <span className="flex items-center gap-1">
+              <Calendar size={16} />
+              <time dateTime={publishedAt}>{publishedAt}</time>
+            </span>
+            <span className="size-1 rounded-full bg-gray-300" />
+            <span className="flex items-center gap-1">
+              <Clock size={16} />
+              <span>{readingTime} min</span>
+            </span>
+          </div>
+        </div>
+      </article>
+    </Link>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -14,7 +14,8 @@ export const Route = createFileRoute("/")({
 })
 
 function HomePage() {
-  const articles = [...allArticles]
+  const articles = allArticles
+    .filter((article) => article.locale === "ja")
     .sort((a, b) => (a.publishedAt < b.publishedAt ? 1 : -1))
     .map((article) => ({
       id: article.id,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,7 +2,6 @@ import { createFileRoute } from "@tanstack/react-router"
 import { allArticles } from "contentlayer/generated"
 import dayjs from "dayjs"
 import { ArticleCard } from "@/components/ArticleCard/ArticleCard"
-import { TranslationNotice } from "@/components/TranslationNotice/TranslationNotice"
 
 export const Route = createFileRoute("/")({
   component: HomePage,
@@ -30,8 +29,6 @@ function HomePage() {
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-8">
-      <TranslationNotice targetLocale="en" href="/en" />
-
       <div className="mb-12">
         <h2 className="mb-2 text-4xl font-bold tracking-tight text-text-primary">
           Latest Writings

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { allArticles } from "contentlayer/generated"
 import dayjs from "dayjs"
 import { ArticleCard } from "@/components/ArticleCard/ArticleCard"
+import { TranslationNotice } from "@/components/TranslationNotice/TranslationNotice"
 
 export const Route = createFileRoute("/")({
   component: HomePage,
@@ -29,6 +30,8 @@ function HomePage() {
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-8">
+      <TranslationNotice targetLocale="en" href="/en" />
+
       <div className="mb-12">
         <h2 className="mb-2 text-4xl font-bold tracking-tight text-text-primary">
           Latest Writings


### PR DESCRIPTION
## 概要

サイトを日英バイリンガル化し、英語版リソースを `/en` 配下にまとめる。既存 19 記事の英訳と英語版ホーム/About を含む。

## 変更内容

### コンテンツ

- Contentlayer に `locale` computed field を追加 (`posts/en/` 配下は `locale: "en"`)
- 既存 19 記事の英訳を `src/markdown/posts/en/{同名}.md` に追加 (Codex で翻訳)

### ルーティング

- `/en` — 英語版ホーム (英語記事一覧)
- `/en/about` — 英語版 About
- `/en/articles/$slug` — 英語版記事
- 日本語版 `/` `/about` `/articles/$slug` に、英語版がある場合の案内バナー (`TranslationNotice`) を表示
- 英語版ページ側にも日本語版への案内バナーを表示

### ヘッダー / ナビ

- `BlogHeader` に言語切替を追加 (Articles / About + 「English」or「日本語」)
- active 判定を `/en` に対応

### 静的生成 / フィード

- OGP 生成 (`scripts/build-ogp.ts`) を拡張:
  - 英語版 PNG: `dist/og/en/{slug}.png`
  - 英語版シェル HTML: `dist/en/articles/{slug}/index.html`
- RSS フィード (`scripts/build-feed.ts`) は日本語版のみ収録

### テスト

- `e2e/en.spec.ts` を新規追加 (英語版ホーム / About / 相互導線)
- `e2e/article.spec.ts` の英語記事テストを新 URL に追従

## 関連Issue

<!-- なし -->

## テスト項目

- [ ] `pnpm typecheck` が通る
- [ ] `pnpm test:e2e` が通る
- [ ] `/` を開いたときに「Read in English」バナーが表示され、`/en` に遷移できる
- [ ] `/about` を開いたときに「Read in English」バナーが表示され、`/en/about` に遷移できる
- [ ] `/en` に英語版記事一覧が表示され、記事カードから `/en/articles/$slug` に遷移できる
- [ ] `/en/about` に英語版 About が表示される
- [ ] 英語版から日本語版へ「日本語で読む」で戻れる
- [ ] `BlogHeader` の言語切替が動作する (日本語版 → English / 英語版 → 日本語)
- [ ] 存在しない slug で `/en/articles/xxx` にアクセスすると 404 になる

## VRT設定

- [x] スナップショットを更新する（英語版ページ新設と、日本語版ページへの案内バナー追加、ヘッダーへの言語切替リンク追加のため）

## スクリーンショット（任意）

<!-- 必要に応じて追加 -->

## 備考

- 既存 19 記事の英訳は Codex (gpt-5.3-codex) による機械翻訳ベース。技術用語は原文表記を尊重するよう指示済。細かな polish は後続 PR で対応予定 (`ja-en-tech-translator` スキルを用意した)。
- 英語版 About のプロフィール情報は `about.tsx` の内容を翻訳したもの。データ共有化は行わず、まずは並置で管理する。