### PR TITLE
docs: 非ランタイムファイルのみの変更時は format check のみで良い旨を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 1. **worktree にいるか確認する**。`main` などのメインの working tree で直接作業しない。必要なら worktree を作る。
 2. **タスクにまつわる情報を集める**。既存コード、関連する docs / スキル、過去の PR / commit を確認する。
 3. **開発する**。バグ修正は先に再現テストを書き、一度 Failed することを確認してから直す。
-4. **PR 作成前チェックを通す**。`pnpm check` / `pnpm typecheck` / `pnpm test:e2e` がすべて通ること。自動修正できるものは `pnpm check:fix`。
+4. **PR 作成前チェックを通す**。
+   - **ブログの動作に影響するコード** (`src/`, `scripts/`, `contentlayer.config.ts`, `vite.config.ts`, `wrangler.jsonc`, `package.json` の deps, ワークフローなど) を変更した場合: `pnpm check` / `pnpm typecheck` / `pnpm test:e2e` がすべて通ること。
+   - **ブログの動作に関係ないファイル** (`.claude/`, `CLAUDE.md`, `README.md`, `docs/`, `dev-assets/` など) しか変更していない場合: **format/lint チェック (`pnpm check`) のみで良い**。typecheck / e2e はスキップ可。
+   - 自動修正できるものは `pnpm check:fix`。
 5. **`/gh:pr` スキルで PR を作る**。
 
 ## スキル / ドキュメントのインデックス

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 1. **worktree にいるか確認する**。`main` などのメインの working tree で直接作業しない。必要なら worktree を作る。
 2. **タスクにまつわる情報を集める**。既存コード、関連する docs / スキル、過去の PR / commit を確認する。
 3. **開発する**。バグ修正は先に再現テストを書き、一度 Failed することを確認してから直す。
-4. **PR 作成前チェックを通す**。
-   - **ブログの動作に影響するコード** (`src/`, `scripts/`, `contentlayer.config.ts`, `vite.config.ts`, `wrangler.jsonc`, `package.json` の deps, ワークフローなど) を変更した場合: `pnpm check` / `pnpm typecheck` / `pnpm test:e2e` がすべて通ること。
-   - **ブログの動作に関係ないファイル** (`.claude/`, `CLAUDE.md`, `README.md`, `docs/`, `dev-assets/` など) しか変更していない場合: **format/lint チェック (`pnpm check`) のみで良い**。typecheck / e2e はスキップ可。
+4. **PR 作成前チェックを通す**。**変更範囲に関わらず `pnpm check` (format/lint) は必ず流す**。
+   - **ブログの動作に影響するコード** (`src/`, `scripts/`, `contentlayer.config.ts`, `vite.config.ts`, `wrangler.jsonc`, `package.json` の deps, ワークフローなど) を変更した場合: 加えて `pnpm typecheck` / `pnpm test:e2e` もすべて通ること。
+   - **ブログの動作に関係ないファイル** (`.claude/`, `CLAUDE.md`, `README.md`, `docs/`, `dev-assets/` など) しか変更していない場合: `pnpm check` のみで良い。typecheck / e2e はスキップ可。
    - 自動修正できるものは `pnpm check:fix`。
 5. **`/gh:pr` スキルで PR を作る**。
 


### PR DESCRIPTION
## 概要

CLAUDE.md の「PR 作成前チェック」に、ブログの動作に関係ないファイル (`.claude/`, `CLAUDE.md`, `README.md`, `docs/`, `dev-assets/` など) のみを変更した場合は、typecheck / e2e をスキップして `pnpm check` (format/lint) のみで良い、というルールを追加する。

## 変更内容

- CLAUDE.md「開発の流れ」ステップ 4 に条件分岐を追加
  - **ランタイムコード変更あり**: `pnpm check` / `pnpm typecheck` / `pnpm test:e2e` を全て通す
  - **非ランタイムファイルのみ**: `pnpm check` のみで良い

## 関連Issue

なし

## テスト項目

- [x] `pnpm check` を通過 (既存の `noImportantStyles` warning のみ、本 PR とは無関係)

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

UI 変更なし。

## スクリーンショット（任意）

なし。

## 備考

CLAUDE.md のみの変更なので、今回追加するルール自体に従い `pnpm check` のみで PR を作成した。