### PR TITLE
ci: Playwright ブラウザキャッシュを有効化し VRT/E2E トリガーを整理

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -22,13 +22,13 @@ runs:
     - name: Install Playwright browsers
       if: steps.playwright-cache.outputs.cache-hit != 'true'
       shell: bash
-      env:
-        PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
       run: |
-        echo "Installing Playwright browsers..."
+        echo "Installing Playwright browsers with system deps..."
         pnpm exec playwright install chromium --with-deps
 
-    - name: Skip browser installation
+    - name: Install Playwright system deps only
       if: steps.playwright-cache.outputs.cache-hit == 'true'
       shell: bash
-      run: echo "Using cached Playwright browsers"
+      run: |
+        echo "Using cached Playwright browsers; installing system deps only..."
+        pnpm exec playwright install-deps chromium

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,6 +7,9 @@ on:
     paths:
       - "src/**"
       - "e2e/**"
+      - "lib/**"
+      - "themes/**"
+      - "public/**"
       - "playwright.config.ts"
       - "package.json"
       - "pnpm-lock.yaml"
@@ -19,10 +22,8 @@ on:
       - "wrangler.jsonc"
       - "tsconfig*.json"
       - ".github/workflows/e2e.yaml"
+      - ".github/actions/setup-playwright/action.yml"
   workflow_dispatch:
-
-env:
-  PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
 
 jobs:
   e2e:

--- a/.github/workflows/vrt.yaml
+++ b/.github/workflows/vrt.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - "src/**"
       - "e2e/**"
+      - "lib/**"
+      - "themes/**"
+      - "public/**"
       - "playwright.config.ts"
       - "package.json"
       - "pnpm-lock.yaml"
@@ -17,8 +20,10 @@ on:
       - "contentlayer.config.ts"
       - "tailwind.config.ts"
       - "postcss.config.cjs"
+      - "wrangler.jsonc"
       - "tsconfig*.json"
       - ".github/workflows/vrt.yaml"
+      - ".github/actions/setup-playwright/action.yml"
   workflow_dispatch:
     inputs:
       update_snapshots:
@@ -32,7 +37,6 @@ env:
   R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-  PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
 
 jobs:
   vrt:


### PR DESCRIPTION
## 概要

VRT / E2E ワークフローの Playwright セットアップが毎回キャッシュミスして Chromium を再ダウンロードしていた問題を直し、あわせてワークフロートリガーを実装/テスト関連の変更に絞り込む。

## 変更内容

- `PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright` を廃止。
  - `~` は Node/Playwright 側で展開されず、ブラウザは実際には `$PWD/~/.cache/ms-playwright/` (=`/home/runner/work/blog/blog/~/.cache/ms-playwright/`) にインストールされていた。
  - 一方 `actions/cache` は `~` を `$HOME/.cache/ms-playwright` に展開してキャッシュしていたため、キャッシュキーが同じでも保存先とインストール先が完全に食い違い、常にミス扱いだった。
  - env を外して Playwright のデフォルト `$HOME/.cache/ms-playwright` に任せることで、`actions/cache` の `path: ~/.cache/ms-playwright` と一致してヒットするようになる。
- `setup-playwright` composite action を分割:
  - キャッシュミス時: `playwright install chromium --with-deps` (バイナリ + システム依存)。
  - キャッシュヒット時: `playwright install-deps chromium` (キャッシュされない OS ライブラリのみ)。以前は `echo` だけで済ませており、環境によっては起動失敗の温床になり得た。
- VRT / E2E のトリガー paths を整理:
  - 追加: `lib/**`, `themes/**`, `public/**`, `.github/actions/setup-playwright/action.yml`。VRT にも `wrangler.jsonc` を追加して E2E とパリティを取る。
  - 実装/テスト/ビルドに関係しないファイル (`.claude/**`, `CLAUDE.md`, `docs/**`, `dev-assets/**` など) では引き続きトリガーされない。

## 関連Issue

なし

## テスト項目

- [ ] 本 PR の VRT / E2E ワークフローが起動し、Setup Playwright ステップで初回はブラウザをインストール → キャッシュに保存されること。
- [ ] 2 回目以降 (同一 Playwright バージョン) の実行で `Cache restored from key: playwright-browsers-Linux-<version>` が出て、`playwright install-deps chromium` のみが走ること。
- [ ] `.claude/` や `CLAUDE.md` など非ランタイムだけを変更した PR で VRT / E2E がトリガーされないこと (別 PR で確認)。

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

UI 変更なし。

## スクリーンショット（任意）

なし。

## 備考

`pnpm check` は worktree 配下 (`.claude/worktrees/**`) からだと biome の `!**/worktrees` によって全ファイルが除外され "No files were processed" で落ちる。これは本 PR の変更前後で同じ挙動 (既存の挙動)。CI では worktree 外で動くので影響しない。