### PR TITLE
ci: E2E/VRT の wait-for-checks を撤去 (CI デッドロック解消)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,65 +25,7 @@ env:
   PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
 
 jobs:
-  wait-for-checks:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for prerequisite checks
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const sha = context.payload.pull_request.head.sha;
-            const required = [
-              { key: 'Check PR Labels', match: (n) => n === 'check-labels' },
-              { key: 'Lint & Format Check', match: (n) => n === 'lint' || n.startsWith('lint (') },
-            ];
-            const timeoutMs = 15 * 60 * 1000;
-            const intervalMs = 15 * 1000;
-            const start = Date.now();
-            while (Date.now() - start < timeoutMs) {
-              const { data } = await github.rest.checks.listForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: sha,
-              });
-              const statuses = required.map(({ key, match }) => {
-                const runs = data.check_runs
-                  .filter((c) => match(c.name))
-                  .sort((a, b) => new Date(b.started_at) - new Date(a.started_at));
-                const latest = runs[0];
-                return {
-                  key,
-                  status: latest?.status ?? 'not_scheduled',
-                  conclusion: latest?.conclusion ?? null,
-                };
-              });
-              core.info(JSON.stringify(statuses));
-              const failed = statuses.filter(
-                (s) =>
-                  s.status === 'completed' &&
-                  !['success', 'neutral', 'skipped'].includes(s.conclusion),
-              );
-              if (failed.length > 0) {
-                core.setFailed(
-                  `Prerequisite failed: ${failed.map((f) => f.key).join(', ')}`,
-                );
-                return;
-              }
-              if (statuses.every((s) => s.status === 'completed')) {
-                core.info('All prerequisite checks passed');
-                return;
-              }
-              await new Promise((r) => setTimeout(r, intervalMs));
-            }
-            core.setFailed('Timed out waiting for prerequisite checks');
-
   e2e:
-    needs: wait-for-checks
-    if: |
-      always() &&
-      (needs.wait-for-checks.result == 'success' ||
-       needs.wait-for-checks.result == 'skipped')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/vrt.yaml
+++ b/.github/workflows/vrt.yaml
@@ -35,65 +35,7 @@ env:
   PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
 
 jobs:
-  wait-for-checks:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for prerequisite checks
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const sha = context.payload.pull_request.head.sha;
-            const required = [
-              { key: 'Check PR Labels', match: (n) => n === 'check-labels' },
-              { key: 'Lint & Format Check', match: (n) => n === 'lint' || n.startsWith('lint (') },
-            ];
-            const timeoutMs = 15 * 60 * 1000;
-            const intervalMs = 15 * 1000;
-            const start = Date.now();
-            while (Date.now() - start < timeoutMs) {
-              const { data } = await github.rest.checks.listForRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: sha,
-              });
-              const statuses = required.map(({ key, match }) => {
-                const runs = data.check_runs
-                  .filter((c) => match(c.name))
-                  .sort((a, b) => new Date(b.started_at) - new Date(a.started_at));
-                const latest = runs[0];
-                return {
-                  key,
-                  status: latest?.status ?? 'not_scheduled',
-                  conclusion: latest?.conclusion ?? null,
-                };
-              });
-              core.info(JSON.stringify(statuses));
-              const failed = statuses.filter(
-                (s) =>
-                  s.status === 'completed' &&
-                  !['success', 'neutral', 'skipped'].includes(s.conclusion),
-              );
-              if (failed.length > 0) {
-                core.setFailed(
-                  `Prerequisite failed: ${failed.map((f) => f.key).join(', ')}`,
-                );
-                return;
-              }
-              if (statuses.every((s) => s.status === 'completed')) {
-                core.info('All prerequisite checks passed');
-                return;
-              }
-              await new Promise((r) => setTimeout(r, intervalMs));
-            }
-            core.setFailed('Timed out waiting for prerequisite checks');
-
   vrt:
-    needs: wait-for-checks
-    if: |
-      always() &&
-      (needs.wait-for-checks.result == 'success' ||
-       needs.wait-for-checks.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 概要

3662b8b で E2E / VRT に追加した \`wait-for-checks\` job が、GitHub-hosted runner の同時実行スロット (20) を占有したまま前提チェックの完了を待ち続けるため、待っている前提チェック (\`Check PR Labels\` / \`Lint & Format Check\`) が queue から進めなくなる循環デッドロックを起こしていた。

実際に E2E / VRT の 20 run が running 状態で 2 時間以上ランナーを掴んだままとなり、新規 PR の CI (本 PR #169 / #171 等の Check PR Labels 含む) が全て queue 詰まりで動かなくなった。

## 変更内容

- \`.github/workflows/e2e.yaml\`: \`wait-for-checks\` job を削除し、\`e2e\` job から \`needs\` / gate \`if\` を除去
- \`.github/workflows/vrt.yaml\`: 同上 (\`vrt\` job から除去)

## 関連Issue

なし

## テスト項目

- [ ] 本 PR で E2E / VRT が待ち合わせなしに並列に動き出すこと
- [ ] Check PR Labels / Lint & Format Check が queue に詰まらず流れること

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし

## 備考

E2E / VRT が Lint 失敗時にスキップされる利点よりも CI 全体を止めるリスクの方が大きいため、いったん並列実行に戻す。今後同じ意図を実現したい場合は、polling ではなく \`workflow_run\` トリガー等、ランナースロットを掴まない方式で再設計する。

なお、既に居座っている 20 run は手動で全て cancel 済み。