### PR TITLE
chore(renovate): PR 同時オープン上限を 10 に引き上げ

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits"],
   "reviewers": ["sh1ma"],
   "labels": ["automated", "chore"],
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 10,
   "prHourlyLimit": 3,
   "rangeStrategy": "bump",
   "packageRules": [


### PR DESCRIPTION
## 概要

Renovate の `prConcurrentLimit` を 5 から 10 に引き上げ、同時に開ける Renovate PR の本数を増やす。

## 変更内容

- `renovate.json` の `prConcurrentLimit` を `5` → `10` に変更

## 関連Issue

なし

## テスト項目

- [ ] `renovate.json` が JSON として妥当 (`biome check renovate.json` OK)
- [ ] 次回の Renovate 実行で同時オープン PR が最大 10 本まで許容されること

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (設定ファイルのみの変更)

## 備考

`prHourlyLimit` は 3 のまま据え置き。1 時間あたりの新規作成ペースは変えず、同時にオープンできる上限だけ広げる意図。