### PR TITLE
docs(claude): E2E はローカル必須から外し Actions 任せに

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 2. **タスクにまつわる情報を集める**。既存コード、関連する docs / スキル、過去の PR / commit を確認する。
 3. **開発する**。バグ修正は先に再現テストを書き、一度 Failed することを確認してから直す。
 4. **PR 作成前チェックを通す**。**変更範囲に関わらず `pnpm check` (format/lint) は必ず流す**。
-   - **ブログの動作に影響するコード** (`src/`, `scripts/`, `contentlayer.config.ts`, `vite.config.ts`, `wrangler.jsonc`, `package.json` の deps, ワークフローなど) を変更した場合: 加えて `pnpm typecheck` / `pnpm test:e2e` もすべて通ること。
-   - **ブログの動作に関係ないファイル** (`.claude/`, `CLAUDE.md`, `README.md`, `docs/`, `dev-assets/` など) しか変更していない場合: `pnpm check` のみで良い。typecheck / e2e はスキップ可。
+   - **ブログの動作に影響するコード** (`src/`, `scripts/`, `contentlayer.config.ts`, `vite.config.ts`, `wrangler.jsonc`, `package.json` の deps, ワークフローなど) を変更した場合: 加えて `pnpm typecheck` も通ること。
+   - **ブログの動作に関係ないファイル** (`.claude/`, `CLAUDE.md`, `README.md`, `docs/`, `dev-assets/` など) しか変更していない場合: `pnpm check` のみで良い。typecheck はスキップ可。
+   - **E2E (`pnpm test:e2e`) は GitHub Actions で必ず流れるので、ローカルで事前に実行する必要はない**。手元で E2E を触りたい場面 (E2E 自体の変更・デバッグ) だけ任意で流す。
    - 自動修正できるものは `pnpm check:fix`。
 5. **`/gh:pr` スキルで PR を作る**。
 


### PR DESCRIPTION
## 概要

`CLAUDE.md` の開発フロー節を更新し、PR 作成前チェックから `pnpm test:e2e` の必須実行を外す。E2E は GitHub Actions で必ず走るので、ローカルで事前に実行する必要はない、というルールに変える。

## 変更内容

- `CLAUDE.md` の「PR 作成前チェックを通す」節から `pnpm test:e2e` の必須実行を削除
- 代わりに「E2E は Actions で必ず流れるのでローカル実行不要。E2E 自体の変更・デバッグ時のみ任意」と明記
- ブログの動作に影響するコード変更時の必須チェックは `pnpm check` + `pnpm typecheck` のみに縮小

## 関連Issue

なし

## テスト項目

- [ ] `CLAUDE.md` の該当節が新しいルールを反映していることを目視確認

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (ドキュメントのみ)

## 備考

Actions で E2E が確実に走るという前提のルール変更。ワークフロー側で E2E ジョブを剥がす場合はこのルールも見直しが必要。