### PR TITLE
feat(about): X/YouTube リンクと作ったもの 3 件を追加

### DIFF
--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { ExternalLink, Github, Sparkles } from "lucide-react"
+import { ExternalLink, Github, Sparkles, Twitter, Youtube } from "lucide-react"
 
 export const Route = createFileRoute("/about")({
   component: AboutPage,
@@ -87,6 +87,30 @@ const projects = [
     href: "https://github.com/sh1ma/iostrace",
     archived: false,
   },
+  {
+    name: "sh1ma/bwpk",
+    tagline: "Bitwarden の passkey を CLI から使う",
+    description:
+      "Bitwarden に保存した passkey (FIDO2/WebAuthn) をコマンドラインから利用するための CLI。マスターパスワードや TouchID で解錠できる。",
+    href: "https://github.com/sh1ma/bwpk",
+    archived: false,
+  },
+  {
+    name: "sh1ma/Angelic-Angel",
+    tagline: "Web Push でツイートをストリーミング受信するサーバー",
+    description:
+      "ブラウザが Web Push を受け取る仕組みを模倣し、その経路経由でツイートをストリーミング受信するサーバー。",
+    href: "https://github.com/sh1ma/Angelic-Angel",
+    archived: false,
+  },
+  {
+    name: "sh1ma/try-k3s-on-cf-workers-public",
+    tagline: "Cloudflare Workers Containers 上で k3s を動かす実験",
+    description:
+      "Cloudflare Workers Containers の中に single-node の k3s クラスタを立てて、Pod をデプロイして遊べるようにする実験プロジェクト。",
+    href: "https://github.com/sh1ma/try-k3s-on-cf-workers-public",
+    archived: false,
+  },
 ]
 
 function AboutPage() {
@@ -134,6 +158,34 @@ function AboutPage() {
               >
                 <Github size={14} />
                 @sh1ma
+              </a>
+            </dd>
+          </div>
+          <div className="flex items-center gap-2">
+            <dt className="text-text-muted">X</dt>
+            <dd>
+              <a
+                href="https://x.com/sh1ma"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-1 font-medium text-brand-primary hover:underline"
+              >
+                <Twitter size={14} />
+                @sh1ma
+              </a>
+            </dd>
+          </div>
+          <div className="flex items-center gap-2">
+            <dt className="text-text-muted">YouTube</dt>
+            <dd>
+              <a
+                href="https://www.youtube.com/@am1hs"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-1 font-medium text-brand-primary hover:underline"
+              >
+                <Youtube size={14} />
+                @am1hs
               </a>
             </dd>
           </div>

--- a/src/routes/en.about.tsx
+++ b/src/routes/en.about.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { ExternalLink, Github, Sparkles } from "lucide-react"
+import { ExternalLink, Github, Sparkles, Twitter, Youtube } from "lucide-react"
 
 export const Route = createFileRoute("/en/about")({
   component: EnglishAboutPage,
@@ -86,6 +86,30 @@ const projects = [
     href: "https://github.com/sh1ma/iostrace",
     archived: false,
   },
+  {
+    name: "sh1ma/bwpk",
+    tagline: "Use Bitwarden passkeys from the CLI",
+    description:
+      "A CLI for using Bitwarden-stored passkeys (FIDO2/WebAuthn) from the command line, with master-password or TouchID unlock.",
+    href: "https://github.com/sh1ma/bwpk",
+    archived: false,
+  },
+  {
+    name: "sh1ma/Angelic-Angel",
+    tagline: "Receive tweets as a Web Push stream",
+    description:
+      "A server that mimics how a browser receives Web Push, then uses that channel to stream tweets in.",
+    href: "https://github.com/sh1ma/Angelic-Angel",
+    archived: false,
+  },
+  {
+    name: "sh1ma/try-k3s-on-cf-workers-public",
+    tagline: "Experiment: running k3s on Cloudflare Workers Containers",
+    description:
+      "An experiment that spins up a single-node k3s cluster inside a Cloudflare Workers Container and lets you deploy pods to it.",
+    href: "https://github.com/sh1ma/try-k3s-on-cf-workers-public",
+    archived: false,
+  },
 ]
 
 function EnglishAboutPage() {
@@ -134,6 +158,34 @@ function EnglishAboutPage() {
               >
                 <Github size={14} />
                 @sh1ma
+              </a>
+            </dd>
+          </div>
+          <div className="flex items-center gap-2">
+            <dt className="text-text-muted">X</dt>
+            <dd>
+              <a
+                href="https://x.com/sh1ma"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-1 font-medium text-brand-primary hover:underline"
+              >
+                <Twitter size={14} />
+                @sh1ma
+              </a>
+            </dd>
+          </div>
+          <div className="flex items-center gap-2">
+            <dt className="text-text-muted">YouTube</dt>
+            <dd>
+              <a
+                href="https://www.youtube.com/@am1hs"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-1 font-medium text-brand-primary hover:underline"
+              >
+                <Youtube size={14} />
+                @am1hs
               </a>
             </dd>
           </div>


### PR DESCRIPTION
## 概要

About ページに SNS リンク (X / YouTube) と、作ったもの 3 件を追加する。

## 変更内容

- ヘッダーの dl に X (`@sh1ma`) と YouTube (`@am1hs`) のリンクを追加
- Projects に以下を追加
  - `sh1ma/bwpk` — Bitwarden の passkey を CLI から使う
  - `sh1ma/Angelic-Angel` — ブラウザが Web Push を受け取る仕組みを模倣してツイートをストリーミング受信するサーバー
  - `sh1ma/try-k3s-on-cf-workers-public` — Cloudflare Workers Containers 上で k3s を動かす実験
- 日本語版 (`src/routes/about.tsx`) と英語版 (`src/routes/en.about.tsx`) の両方を更新

## 関連Issue

なし

## テスト項目

- [ ] `/about` を開き、X と YouTube のリンクが表示され、それぞれ正しい URL に飛ぶことを確認
- [ ] `/about` の Projects に追加した 3 件が表示され、GitHub リポジトリに飛ぶことを確認
- [ ] `/en/about` でも同様に追加が反映されていることを確認

## VRT設定

- [x] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

## 備考

`pnpm check` は worktree 配下が `.gitignore` で除外されているため直接実行時は "No files were processed" になる。個別ファイル指定で biome check は clean。`tsc -b --noEmit` は pass。