### PR TITLE
fix: モバイルサイズで横 overflow が発生していたのを解消

### DIFF
--- a/src/components/ArticleCard/ArticleCard.tsx
+++ b/src/components/ArticleCard/ArticleCard.tsx
@@ -42,16 +42,16 @@ export const ArticleCard = ({
           )}
         </div>
 
-        <div className="flex flex-1 flex-col gap-2">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
           {tags && tags.length > 0 && (
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               {tags.map((tag) => (
                 <Tag key={tag} label={tag} size="sm" />
               ))}
             </div>
           )}
 
-          <h3 className="text-xl font-bold leading-tight text-brand-primary transition-colors group-hover:underline">
+          <h3 className="text-xl font-bold leading-tight break-words text-brand-primary transition-colors group-hover:underline">
             {title}
           </h3>
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -59,6 +59,7 @@
 html,
 body {
   @apply bg-bg-base;
+  overflow-x: clip;
   font-family:
     "Inter",
     "Noto Sans JP",
@@ -257,6 +258,12 @@ body {
 }
 .prose tbody tr:nth-child(even) {
   background: rgba(0, 0, 0, 0.02);
+}
+
+/* インライン code の折り返し (長い URL / パスで overflow しないように) */
+.prose :not(pre) > code {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* KaTeX 数式ブロックの横スクロール */


### PR DESCRIPTION
## 概要

モバイルサイズ (iOS など幅 375px 想定) でページを閲覧すると、コンテンツが viewport 幅を超えて横スクロールバーが表示されていたのを修正する。

## 変更内容

- `src/components/ArticleCard/ArticleCard.tsx`: 記事カードの `flex-1` 子要素に `min-w-0` を付与し、`h3` タイトルに `break-words` を追加。タグ列の `flex` に `flex-wrap` を追加して、長いタイトル / タグ数が多い場合に親幅を突き抜けないようにした。
- `src/globals.css`: `.prose :not(pre) > code` に `overflow-wrap: anywhere` / `word-break: break-word` を追加。長いパスやコマンドを含む inline code が折り返せず overflow していたのを解消。
- `src/globals.css`: 保険として `html, body` に `overflow-x: clip` を追加 (`hidden` と違い containing block 化しないので sticky を壊さない)。

## 関連Issue

なし

## テスト項目

- [x] モバイル幅 (375px) でトップページに横スクロールバーが出ないこと (`documentElement.scrollWidth === clientWidth`)
- [x] モバイル幅で記事ページ (`/articles/20260705_k3s_on_cloudflare_workers` 等、長い inline code を含む記事) に横スクロールバーが出ないこと
- [x] モバイル幅で `/about` に横スクロールバーが出ないこと
- [x] pre / code ブロック内部の横スクロール (意図的なもの) は従来通り動くこと

## VRT設定

- [x] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

Chrome DevTools MCP のモバイルエミュレーション (375x812) で `documentElement.scrollWidth === 375` であることを確認済み。

## 備考

`min-w-0` は flex アイテムのデフォルト `min-width: auto` を打ち消すためのもので、flexbox の overflow の典型的な原因への対処。