### PR TITLE
feat: sitemap.xml を生成する

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm build:content && vite",
-    "build": "pnpm gen && tsc -b && vite build && pnpm build:feed && pnpm build:ogp",
+    "build": "pnpm gen && tsc -b && vite build && pnpm build:feed && pnpm build:sitemap && pnpm build:ogp",
     "gen": "pnpm build:content && pnpm build:routes",
     "build:content": "contentlayer2 build",
     "build:routes": "tsr generate",
     "build:feed": "tsx scripts/build-feed.ts",
+    "build:sitemap": "tsx scripts/build-sitemap.ts",
     "build:ogp": "tsx scripts/build-ogp.ts",
     "preview": "pnpm build && wrangler dev",
     "deploy": "pnpm build && wrangler deploy",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-Agent: *
 Allow: /
+
+Sitemap: https://blog.sh1ma.dev/sitemap.xml

--- a/scripts/build-sitemap.ts
+++ b/scripts/build-sitemap.ts
@@ -1,0 +1,66 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { allArticles } from "../.contentlayer/generated/index.mjs"
+
+const SITE_URL = process.env.SITE_URL ?? "https://blog.sh1ma.dev"
+const OUT_DIR = path.resolve("./dist")
+const OUT_FILE = path.join(OUT_DIR, "sitemap.xml")
+
+type UrlEntry = {
+  loc: string
+  lastmod?: Date
+}
+
+const XML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  "'": "&apos;",
+  '"': "&quot;",
+}
+
+const escapeXml = (value: string): string =>
+  value.replace(/[&<>'"]/g, (c) => XML_ESCAPE_MAP[c] ?? c)
+
+const resolveUrl = (pathname: string): string =>
+  new URL(pathname, SITE_URL).toString()
+
+const urlToXml = (entry: UrlEntry): string => {
+  const children: string[] = [`<loc>${escapeXml(entry.loc)}</loc>`]
+  if (entry.lastmod) {
+    children.push(`<lastmod>${entry.lastmod.toISOString()}</lastmod>`)
+  }
+  return `  <url>\n${children.map((c) => `    ${c}`).join("\n")}\n  </url>`
+}
+
+const buildSitemapXml = (entries: UrlEntry[]): string => {
+  const body = entries.map(urlToXml).join("\n")
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    body,
+    "</urlset>",
+    "",
+  ].join("\n")
+}
+
+const staticEntries: UrlEntry[] = [
+  { loc: resolveUrl("/") },
+  { loc: resolveUrl("/about") },
+  { loc: resolveUrl("/en/") },
+  { loc: resolveUrl("/en/about") },
+]
+
+const articleEntries: UrlEntry[] = allArticles.map((article) => {
+  const prefix = article.locale === "en" ? "/en/articles" : "/articles"
+  return {
+    loc: resolveUrl(`${prefix}/${article.id}`),
+    lastmod: new Date(article.publishedAt),
+  }
+})
+
+const entries: UrlEntry[] = [...staticEntries, ...articleEntries]
+
+await mkdir(OUT_DIR, { recursive: true })
+await writeFile(OUT_FILE, buildSitemapXml(entries), "utf-8")
+console.log(`Wrote ${OUT_FILE} (${entries.length} urls)`)


### PR DESCRIPTION
## 概要

Next.js 時代に生成されていた sitemap.xml が Vite + Contentlayer 構成では失われていたため、build 時に生成するスクリプトを追加する。

## 変更内容

- `scripts/build-sitemap.ts` を新規追加。依存追加なしで `dist/sitemap.xml` を出力する。
  - `urlToXml` / `buildSitemapXml` / `escapeXml` / `resolveUrl` に責務を分離し、文字列連結ベースの flaky さを避けた構造にした。
  - URL 組み立ては `new URL(path, SITE_URL)` に任せ、XML の特殊文字 5 種を `escapeXml` で安全にエスケープする。
  - 静的ルート (`/`, `/about`, `/en/`, `/en/about`) と Contentlayer の `allArticles` (ja / en) を列挙し、記事には `<lastmod>` (publishedAt の ISO 8601) を付与。
- `package.json` の `build` チェーンに `build:sitemap` を組み込み、`build:feed` の直後に実行するようにした。
- `public/robots.txt` に `Sitemap: https://blog.sh1ma.dev/sitemap.xml` を追記。

## 関連Issue

なし

## テスト項目

- [ ] `pnpm build:sitemap` が成功し、`dist/sitemap.xml` に静的 4 URL + 全記事の URL が出力される。
- [ ] 出力された sitemap.xml が Well-formed な XML であり、`<loc>` / `<lastmod>` が仕様どおり入っている。
- [ ] デプロイ後 `https://blog.sh1ma.dev/sitemap.xml` にアクセスできる。
- [ ] `https://blog.sh1ma.dev/robots.txt` に `Sitemap:` 行が含まれる。

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (UI 変更なし)

## 備考

- 依存追加なしで済ませたかったため、`feed` パッケージのような XML ライブラリは使わず、自前で最小の XML を組み立てている。
- `SITE_URL` は `process.env.SITE_URL` で上書き可能 (デフォルト `https://blog.sh1ma.dev`)。