### PR TITLE
docs(skills): deploy スキルを追加

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: deploy
+description: このブログ (`sh1ma/blog`) を本番環境 (blog.sh1ma.dev) にデプロイするための本番PRを起動する。「デプロイして」「本番出して」「本番にあげて」「リリースして」「リリースする」「production PR 作って」など、本番反映を意図した依頼で必ず発動する。staging は main への push で自動デプロイされるためこのスキルの対象外。
+---
+
+# deploy (本番リリース)
+
+`sh1ma/blog` の本番デプロイフローを起動する。
+
+## デプロイフローの全体像
+
+一次ソース: `.github/workflows/` 配下の各 yaml。要点だけ:
+
+- `main` に push → `staging-deploy.yaml` が自動で staging に反映。
+- `Create Production PR` ワークフロー (`create-production-pr.yaml`) を **手動起動** → `main` → `deploy` の PR が作られる。
+- その PR をマージ → `deploy` ブランチに push されて `production-deploy.yaml` が本番へデプロイ。
+
+このスキルが担当するのは **真ん中の「手動起動」の一手だけ**。PR のマージやマージ後の状況は担当しない (必要なら `gh:pr` スキルを使う)。
+
+## やること
+
+1. **前提を確認する**。
+   - `main` が最新かつ CI が通っている想定。心配ならユーザに ask する。
+   - 既に open な本番 PR (base: `deploy`, head: `main`) がないかを `gh pr list` で確認する。ある場合は起動せずユーザに存在を伝える (ワークフロー側でも重複作成は防いでいるが、無駄な run を避ける)。
+2. **`Create Production PR` ワークフローを起動する**。
+   - 使うコマンドは `gh workflow run`。フラグは実行時に `gh workflow run --help` で確認する。ワークフローファイル名は `create-production-pr.yaml`。
+   - 対象ブランチは `main` (workflow_dispatch なのでこのワークフロー定義があるブランチで走る)。
+3. **結果を報告する**。
+   - 起動した run の URL を `gh run list --workflow=create-production-pr.yaml --limit 1` などから取り、ユーザに日本語で伝える。
+   - 「マージすると本番反映される」ことも一言添える。マージ自体はユーザの判断。
+
+## 絶対に守るルール
+
+- **対象リポジトリは `sh1ma/blog` のみ**。`--repo` で他リポジトリを指定しない。
+- **勝手にマージまでしない**。このスキルは PR 作成の起動まで。マージするか、いつマージするかはユーザが決める。
+- **staging を触ろうとしない**。staging は `main` push で自動なので、このスキルからは何もしない。
+- **`gh` CLI の具体的なフラグは記憶で使わず、`--help` で確認する**。関連は [`gh` スキル](../gh/SKILL.md)。


### PR DESCRIPTION
## 概要

本番デプロイ用の PR 作成 (`Create Production PR` ワークフロー / `workflow_dispatch`) を起動するための `deploy` スキルを追加する。「デプロイして」「本番出して」「リリース」など、本番反映を意図した依頼で発動する。

## 変更内容

- `.claude/skills/deploy/SKILL.md` を新規追加。
  - スコープは本番 PR 作成の起動 (`gh workflow run create-production-pr.yaml`) のみ。
  - staging は `main` push で自動デプロイのためスキル対象外と明記。
  - マージ判断はユーザに委ねる旨を明記。
  - 具体的な `gh` フラグは書かず、`--help` で確認する方針 (プロジェクトのスキル作成方針に準拠)。

## 関連Issue

なし

## テスト項目

- [ ] スキルの description に想定トリガー語 (デプロイ / 本番出す / リリース 等) が含まれている
- [ ] 本文が既存の `gh` スキル群と整合的なスタイル (help 参照方針・対象リポジトリ限定など)

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし

## 備考

`.claude/` 配下のみの変更で、ブログの動作コードには影響しない。biome は `**/*.md` と `**/worktrees` を除外設定しているため lint 対象外。typecheck も対象外。