### PR TITLE
chore: wrangler compatibility_date を 2026-07-06 に更新

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "blog",
-  "compatibility_date": "2025-04-01",
+  "compatibility_date": "2026-07-06",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "assets": {
     "not_found_handling": "single-page-application",


### PR DESCRIPTION
## 概要

`wrangler.jsonc` の `compatibility_date` が `2025-04-01` と古くなっていたため、Cloudflare 公式ドキュメントの推奨に沿って本日の日付 (`2026-07-06`) に更新する。

## 変更内容

- `wrangler.jsonc`: `compatibility_date` を `2025-04-01` → `2026-07-06` に更新

なお `observability.enabled` は既に `true` で有効化済みのため今回の変更なし。

## 関連Issue

なし

## テスト項目

- [x] `pnpm typecheck` が通ること
- [x] biome check が通ること (worktree ディレクトリは biome の除外対象なので `wrangler.jsonc` を直接指定して確認)
- [ ] CI (E2E 含む) が通ること
- [ ] staging デプロイ後、サイトが正常動作すること

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (設定変更のみ)

## 備考

Cloudflare の compatibility date は「今日の日付」を指定するのが公式推奨。runtime の破壊的変更は日付境界で入るため、更新後は staging での挙動確認を推奨する。