### PR TITLE
feat: RSS を /feed で公開し Footer にリンクを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ tmp
 .open-next
 
 # git worktrees
-worktrees/
+/worktrees/
 
 # assets for development
 dev-assets

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,7 @@
       "!**/.wrangler",
       "!**/dist",
       "!**/dev-assets",
-      "!**/worktrees",
+      "!worktrees",
       "!**/playwright-report",
       "!**/test-results",
       "!**/public",

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       rel="alternate"
       type="application/rss+xml"
       title="blog.sh1ma.dev"
-      href="/feed.xml"
+      href="/feed"
     />
     <title>blog.sh1ma.dev</title>
     <meta name="description" content="sh1maのブログです" />

--- a/public/_headers
+++ b/public/_headers
@@ -1,2 +1,5 @@
 /_next/static/*
   Cache-Control: public,max-age=31536000,immutable
+
+/feed
+  Content-Type: application/rss+xml; charset=utf-8

--- a/scripts/build-feed.ts
+++ b/scripts/build-feed.ts
@@ -6,12 +6,12 @@ import { allArticles } from "../.contentlayer/generated/index.mjs"
 
 const SITE_URL = process.env.SITE_URL ?? "https://blog.sh1ma.dev"
 const OUT_DIR = path.resolve("./dist")
-const OUT_FILE = path.join(OUT_DIR, "feed.xml")
+const OUT_FILE = path.join(OUT_DIR, "feed")
 
 const feed = new Feed({
   title: "blog.sh1ma.dev",
   description: "sh1maのブログです",
-  feedLinks: { rss: `${SITE_URL}/feed.xml` },
+  feedLinks: { rss: `${SITE_URL}/feed` },
   link: SITE_URL,
   id: SITE_URL,
   language: "ja",

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { Github, PenLine } from "lucide-react"
+import { Github, PenLine, Rss } from "lucide-react"
 
 export const Footer = () => {
   const currentYear = new Date().getFullYear()
@@ -29,6 +29,13 @@ export const Footer = () => {
             aria-label="GitHub"
           >
             <Github className="size-5" />
+          </a>
+          <a
+            href="/feed"
+            className="text-text-muted transition-all duration-300 hover:-translate-y-1 hover:text-brand-primary"
+            aria-label="RSS"
+          >
+            <Rss className="size-5" />
           </a>
         </div>
       </div>


### PR DESCRIPTION
## 概要

RSS フィードの公開 URL を `/feed.xml` から `/feed` に変更し、Footer に RSS リンクを追加した。あわせて、worktree 内で `pnpm check` (biome) が対象ファイル 0 件になる問題を修正した。

## 変更内容

- `scripts/build-feed.ts`: 出力先を `dist/feed.xml` → `dist/feed`、`feedLinks.rss` も `/feed` に
- `index.html`: `<link rel="alternate" type="application/rss+xml">` の href を `/feed` に
- `public/_headers`: 拡張子なしファイルで Content-Type を推定できないため、`/feed` に `application/rss+xml; charset=utf-8` を明示
- `src/components/Footer/Footer.tsx`: RSS アイコンリンク (`/feed`) を追加
- `.gitignore`: `worktrees/` → `/worktrees/` (repo root 限定に)
- `biome.json`: `!**/worktrees` → `!worktrees` (worktree の絶対パスに `worktrees` セグメントが含まれるため、`**/worktrees` だと CWD 全体が除外される)

## 関連Issue

なし

## テスト項目

- [ ] デプロイ後 `https://blog.sh1ma.dev/feed` が RSS2.0 として取得でき、`Content-Type: application/rss+xml` が返ること
- [ ] トップページの `<link rel="alternate">` から RSS リーダーがフィードを自動検出できること
- [ ] Footer に RSS アイコンが表示され、クリックで `/feed` に遷移すること
- [ ] 旧 URL (`/feed.xml`) が使えなくなる点は許容 (講読者ゼロに近い個人ブログのため)

## VRT設定

- [x] スナップショットを更新する（Footer に RSS アイコンを 1 つ追加）

## スクリーンショット（任意）

## 備考

`/feed.xml` は廃止するため、既存の講読者がいる場合は再登録が必要。