### PR TITLE
fix(ci): create-production-pr の YAML 破損を修正

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -25,8 +25,11 @@ description: このブログ (`sh1ma/blog`) を本番環境 (blog.sh1ma.dev) に
 2. **`Create Production PR` ワークフローを起動する**。
    - 使うコマンドは `gh workflow run`。フラグは実行時に `gh workflow run --help` で確認する。ワークフローファイル名は `create-production-pr.yaml`。
    - 対象ブランチは `main` (workflow_dispatch なのでこのワークフロー定義があるブランチで走る)。
-3. **結果を報告する**。
-   - 起動した run の URL を `gh run list --workflow=create-production-pr.yaml --limit 1` などから取り、ユーザに日本語で伝える。
+3. **run の完走を確認する**。
+   - 起動しっぱなしにしない。`gh run watch` などで完走まで見届け、`conclusion` が `success` であることを確認する。
+   - 失敗していたら報告して調査する。「起動した」で終わらせない (過去、workflow YAML が壊れて全 run が失敗していたのに気付かれなかった実績あり)。
+4. **結果を報告する**。
+   - 完走した run の URL と、新しく作られた本番 PR (base: `deploy`, head: `main`) の URL を `gh pr list` から取り、ユーザに日本語で伝える。
    - 「マージすると本番反映される」ことも一言添える。マージ自体はユーザの判断。
 
 ## 絶対に守るルール

--- a/.github/workflows/create-production-pr.yaml
+++ b/.github/workflows/create-production-pr.yaml
@@ -52,20 +52,24 @@ jobs:
             echo "PR #$EXISTING_PR already exists"
           else
             # PRを作成
+            BODY=$(cat <<'EOF'
+          ## 本番デプロイ
+
+          このPRをマージすると本番環境へのデプロイが実行されます。
+
+          ### チェックリスト
+          - [ ] staging環境で動作確認済み
+          - [ ] すべてのテストがパス
+          - [ ] 破壊的変更がないことを確認
+
+          ---
+          *このPRは自動生成されました*
+          EOF
+          )
             gh pr create \
               --base deploy \
               --head main \
               --title "本番デプロイ: $(date +'%Y-%m-%d %H:%M:%S')" \
-              --body "## 本番デプロイ
-
-このPRをマージすると本番環境へのデプロイが実行されます。
-
-### チェックリスト
-- [ ] staging環境で動作確認済み
-- [ ] すべてのテストがパス
-- [ ] 破壊的変更がないことを確認
-
----
-*このPRは自動生成されました*" \
+              --body "$BODY" \
               --label "production"
           fi


### PR DESCRIPTION
## 概要

`Create Production PR` ワークフロー (`create-production-pr.yaml`) が YAML パースに失敗しており、`workflow_dispatch` トリガーが登録されず `gh workflow run` が 422 で弾かれる状態になっていた。push のたびに空の failure run が積み上がっていたのを修正する。

原因は `gh pr create --body "..."` の複数行文字列。`run: |` ブロックスカラの基底インデント (10 sp) を無視して列 0 から始まっていたため、YAML パーサがブロックスカラを途中で終了させて workflow 全体が壊れていた (途中の `---` は YAML のドキュメント区切りとして解釈されていた)。

## 変更内容

- `.github/workflows/create-production-pr.yaml`: PR 本文をヒアドキュメント (`cat <<'EOF'`) で組み立て、全行を `run: |` の基底インデント以上に揃えて YAML 的に有効な形にした。
- `.claude/skills/deploy/SKILL.md`: run 完走を確認するステップを追加。今回の障害が「起動しっぱなしで気付かない」パターンだったため、次からは `conclusion` を検証し、作成された本番 PR の URL まで報告する。

## 関連Issue

なし。

## テスト項目

- [x] ローカルで `python3 -c "import yaml; ..."` により YAML が正しくパースされ、`on: workflow_dispatch` が認識されることを確認。
- [ ] マージ後、Actions から `Create Production PR` を手動起動し、run が success で終わり `main → deploy` の PR が作成されることを確認。

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (workflow / skill のみの変更)。

## 備考

`pnpm check` は worktree 内で実行すると biome の `!**/worktrees` glob により `.` 全体が ignore されて exit 1 になる (既知の worktree 側の制約)。今回の変更 (`.yaml` / `.md`) は biome の対象外なので CI では通る想定。