### PR TITLE
fix(ci): create-production-pr のラベルを実在する release に変更

### DIFF
--- a/.github/workflows/create-production-pr.yaml
+++ b/.github/workflows/create-production-pr.yaml
@@ -71,5 +71,5 @@ jobs:
               --head main \
               --title "本番デプロイ: $(date +'%Y-%m-%d %H:%M:%S')" \
               --body "$BODY" \
-              --label "production"
+              --label "release"
           fi


### PR DESCRIPTION
## 概要

`Create Production PR` ワークフローが `--label \"production\"` を付けようとするが、当リポジトリにその名前のラベルは存在しない。結果として `gh pr create` が `could not add label: 'production' not found` で exit 1 になり、本番 PR が作られない状態だった。

## 変更内容

- `.github/workflows/create-production-pr.yaml`: `gh pr create --label` を `production` → `release` に変更。`gh label list` に実在するリリース用ラベル (description: 「リリースタグ」) に揃えた。

## 関連Issue

なし。#192 の続き。

## テスト項目

- [ ] マージ後に `Create Production PR` を手動起動し、run が success で終わり `main → deploy` の PR が `release` ラベル付きで作られることを確認。

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし。

## 備考

deploy スキルからの起動中に判明。ラベル体系はドキュメント/スキル側では都度 `gh label list` で確認するようになっているが、ワークフローだけは値をハードコードしているため、ラベルが renamed/removed されると壊れる。今回は release ラベルが定着しているので値固定のままとした。