### PR TITLE
feat: Google Analytics を追加し Footer に利用を明示

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,15 @@
     />
     <title>blog.sh1ma.dev</title>
     <meta name="description" content="sh1maのブログです" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-LZYCBK9WJY"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-LZYCBK9WJY');
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -18,6 +18,9 @@ export const Footer = () => {
           <p className="text-sm text-text-muted">
             © {currentYear} sh1ma. All rights reserved.
           </p>
+          <p className="mt-2 text-xs text-text-muted">
+            このサイトはアクセス解析のため Google Analytics を利用しています。
+          </p>
         </div>
 
         <div className="flex gap-6">


### PR DESCRIPTION
## 概要

Google Analytics (gtag.js, 測定 ID: `G-LZYCBK9WJY`) をサイトに導入し、Footer に GA 利用の旨を明示した。

## 変更内容

- `index.html` の `<head>` に Google tag (gtag.js) スニペットを追加
- `src/components/Footer/Footer.tsx` に「このサイトはアクセス解析のため Google Analytics を利用しています。」の一文を追加

## 関連Issue

なし

## テスト項目

- [ ] 本番/staging で `gtag/js?id=G-LZYCBK9WJY` がロードされ、GA 側でリアルタイム計測が確認できる
- [ ] Footer に GA 利用の旨が表示される

## VRT設定

- [x] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

Footer に一行追加のみ。

## 備考

初期実装のため SPA 遷移時の追加 `page_view` 送信は入れていない。必要になったら Router の subscribe で `gtag('event', 'page_view', ...)` を追加する。