### PR TITLE
fix(BlogHeader): スクロール閾値にヒステリシスを入れちらつきを解消

### DIFF
--- a/src/components/BlogHeader/BlogHeader.tsx
+++ b/src/components/BlogHeader/BlogHeader.tsx
@@ -3,7 +3,8 @@ import { allArticles } from "contentlayer/generated"
 import { ChevronLeft, Link as LinkIcon } from "lucide-react"
 import { useCallback, useEffect, useRef, useState } from "react"
 
-const SCROLL_THRESHOLD = 80
+const SCROLL_COMPACT_THRESHOLD = 80
+const SCROLL_EXPAND_THRESHOLD = 40
 const HIDE_DELAY_MS = 3000
 const AUTO_COLLAPSE_DELAY_MS = 3000
 
@@ -76,7 +77,7 @@ export const BlogHeader = () => {
 
   const scheduleHide = useCallback(() => {
     clearHideTimer()
-    if (window.scrollY > SCROLL_THRESHOLD && !userExpandedRef.current) {
+    if (window.scrollY > SCROLL_COMPACT_THRESHOLD && !userExpandedRef.current) {
       hideTimerRef.current = setTimeout(() => setVisible(false), HIDE_DELAY_MS)
     }
   }, [clearHideTimer])
@@ -95,16 +96,21 @@ export const BlogHeader = () => {
 
   useEffect(() => {
     const onActivity = () => {
-      const s = window.scrollY > SCROLL_THRESHOLD
-      setScrolled(s)
-      if (!s && userExpandedRef.current) {
-        setUserExpanded(false)
-        userExpandedRef.current = false
-        if (collapseTimerRef.current) {
-          clearTimeout(collapseTimerRef.current)
-          collapseTimerRef.current = undefined
+      setScrolled((prev) => {
+        const y = window.scrollY
+        const next = prev
+          ? y > SCROLL_EXPAND_THRESHOLD
+          : y > SCROLL_COMPACT_THRESHOLD
+        if (!next && userExpandedRef.current) {
+          setUserExpanded(false)
+          userExpandedRef.current = false
+          if (collapseTimerRef.current) {
+            clearTimeout(collapseTimerRef.current)
+            collapseTimerRef.current = undefined
+          }
         }
-      }
+        return next
+      })
       setVisible(true)
       scheduleHide()
     }


### PR DESCRIPTION
## 概要

Chrome でページを少しだけスクロールすると、ヘッダーが展開 (72px) と縮小 (48px) を高速に往復してちらつくバグを修正する。

## 変更内容

- `SCROLL_THRESHOLD` (単一の閾値 80) を廃止し、`SCROLL_COMPACT_THRESHOLD = 80` / `SCROLL_EXPAND_THRESHOLD = 40` のヒステリシスに変更。
- `onActivity` を `setScrolled` の関数更新形に変え、直前状態を元に「compact 化は 80 超え / 展開復帰は 40 未満」で判定するようにした。

## 関連Issue

なし

## 原因

`window.scrollY > 80` の単一閾値で `isCompact` を切り替えていた。閾値付近ではヘッダー自体の高さが 72px⇄48px と変化し、それによって sticky ヘッダー以降のレイアウトが上下に揺れ、scrollY が閾値を再びまたいで発振していた。特に Chrome の inertial スクロールで顕著。

## テスト項目

- [ ] Chrome (macOS / iOS) で少しだけスクロールしたときにヘッダーがちらつかない
- [ ] scrollY を 80 以上まで進めるとヘッダーが円形にコンパクト化する
- [ ] コンパクト化した状態から scrollY 40 未満まで戻すとヘッダーが元のサイズに戻る
- [ ] スクロール停止後 3 秒でヘッダーがフェードアウトする既存挙動が維持されている

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

UI の見た目自体は変更なし (閾値のみ)、VRT 更新不要。

## スクリーンショット（任意）

なし (振動バグの再現は動画でないと見えないため省略)。

## 備考

なし。