### PR TITLE
feat: 英語版RSSフィード /en/feed を追加

### DIFF
--- a/scripts/build-feed.ts
+++ b/scripts/build-feed.ts
@@ -6,31 +6,63 @@ import { allArticles } from "../.contentlayer/generated/index.mjs"
 
 const SITE_URL = process.env.SITE_URL ?? "https://blog.sh1ma.dev"
 const OUT_DIR = path.resolve("./dist")
-const OUT_FILE = path.join(OUT_DIR, "feed")
 
-const feed = new Feed({
-  title: "blog.sh1ma.dev",
-  description: "sh1maのブログです",
-  feedLinks: { rss: `${SITE_URL}/feed` },
-  link: SITE_URL,
-  id: SITE_URL,
-  language: "ja",
-  copyright: `All rights reserved ${dayjs().format("YYYY")}, sh1ma`,
-})
-
-const feedArticles = allArticles
-  .filter((article) => article.locale === "ja")
-  .sort((a, b) => (a.sortKey < b.sortKey ? 1 : -1))
-
-for (const article of feedArticles) {
-  feed.addItem({
-    title: article.title,
-    description: article.description ?? "",
-    link: `${SITE_URL}/articles/${article.id}`,
-    date: dayjs(article.publishedAt).toDate(),
-  })
+type LocaleFeedConfig = {
+  locale: "ja" | "en"
+  outFile: string
+  feedPath: string
+  articlePathPrefix: string
+  title: string
+  description: string
+  language: string
 }
 
-await mkdir(OUT_DIR, { recursive: true })
-await writeFile(OUT_FILE, feed.rss2(), "utf-8")
-console.log(`Wrote ${OUT_FILE} (${feedArticles.length} items)`)
+const FEED_CONFIGS: LocaleFeedConfig[] = [
+  {
+    locale: "ja",
+    outFile: path.join(OUT_DIR, "feed"),
+    feedPath: "/feed",
+    articlePathPrefix: "/articles",
+    title: "blog.sh1ma.dev",
+    description: "sh1maのブログです",
+    language: "ja",
+  },
+  {
+    locale: "en",
+    outFile: path.join(OUT_DIR, "en", "feed"),
+    feedPath: "/en/feed",
+    articlePathPrefix: "/en/articles",
+    title: "blog.sh1ma.dev (English)",
+    description: "sh1ma's blog (English)",
+    language: "en",
+  },
+]
+
+for (const config of FEED_CONFIGS) {
+  const feed = new Feed({
+    title: config.title,
+    description: config.description,
+    feedLinks: { rss: `${SITE_URL}${config.feedPath}` },
+    link: SITE_URL,
+    id: `${SITE_URL}${config.feedPath}`,
+    language: config.language,
+    copyright: `All rights reserved ${dayjs().format("YYYY")}, sh1ma`,
+  })
+
+  const feedArticles = allArticles
+    .filter((article) => article.locale === config.locale)
+    .sort((a, b) => (a.sortKey < b.sortKey ? 1 : -1))
+
+  for (const article of feedArticles) {
+    feed.addItem({
+      title: article.title,
+      description: article.description ?? "",
+      link: `${SITE_URL}${config.articlePathPrefix}/${article.id}`,
+      date: dayjs(article.publishedAt).toDate(),
+    })
+  }
+
+  await mkdir(path.dirname(config.outFile), { recursive: true })
+  await writeFile(config.outFile, feed.rss2(), "utf-8")
+  console.log(`Wrote ${config.outFile} (${feedArticles.length} items)`)
+}


### PR DESCRIPTION
## 概要

英語記事だけを含む RSS フィード `/en/feed` を追加する。既存の `/feed` は日本語記事だけを含むフィードとして維持。

## 変更内容

- `scripts/build-feed.ts` を書き換え、ロケール別の設定を配列で回して以下の 2 ファイルを生成するようにした:
  - `dist/feed` — 日本語記事 (`locale === "ja"`)、記事リンクは `/articles/{id}`、`language: ja`
  - `dist/en/feed` — 英語記事 (`locale === "en"`)、記事リンクは `/en/articles/{id}`、`language: en`
- チャンネルの `title` / `description` / `id` / `atom:link` は各ロケール向けに設定 (英語版は `blog.sh1ma.dev (English)` / `sh1ma's blog (English)`)。
- `not_found_handling: single-page-application` のもと、`dist/en/feed` は `/en/feed` として配信される (既存の `dist/feed` → `/feed` と同じ挙動)。

## 関連Issue

なし

## テスト項目

- [ ] `pnpm build:feed` が成功し、`dist/feed` と `dist/en/feed` の両方が生成される
- [ ] `dist/en/feed` の各 item の `<link>` が `https://blog.sh1ma.dev/en/articles/...` になっている
- [ ] `dist/feed` の内容 (item 数・link) が従来と変わらない
- [ ] デプロイ後、`https://blog.sh1ma.dev/en/feed` が RSS として取得できる

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (バックエンド/ビルド成果物のみの変更)

## 備考

Footer の RSS リンクは現状 `/feed` を指したまま。英語ページで `/en/feed` に切り替えるかは別 PR で検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)