### PR TITLE
ci: create production PR で PR_CREATE_TOKEN を使う

### DIFF
--- a/.github/workflows/create-production-pr.yaml
+++ b/.github/workflows/create-production-pr.yaml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.PR_CREATE_TOKEN }}
 
       - name: Setup Git
         run: |
@@ -34,7 +35,7 @@ jobs:
 
       - name: Create PR from main to deploy
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_CREATE_TOKEN }}
         run: |
           # mainブランチに切り替え
           git checkout main


### PR DESCRIPTION
## 概要

本番デプロイ PR を作成するワークフロー (`.github/workflows/create-production-pr.yaml`) が使う GitHub トークンを、デフォルトの `GITHUB_TOKEN` から PAT (`secrets.PR_CREATE_TOKEN`) に切り替える。

デフォルトの `GITHUB_TOKEN` で作成された PR は他のワークフロー (VRT / lint / e2e など) を発火させないため、自動生成の本番 PR で CI が回らない問題があった。PAT を使うことでこれらの workflow_run / pull_request トリガが正しく起動する。

## 変更内容

- `actions/checkout@v6` の `token` に `secrets.PR_CREATE_TOKEN` を指定
- `gh pr create` ステップの `GH_TOKEN` を `secrets.PR_CREATE_TOKEN` に変更
- リポジトリの Actions Secrets に `PR_CREATE_TOKEN` を登録済み (`GITHUB_` プレフィックスは GitHub 側で禁止のため名称変更)

## 関連Issue

なし

## テスト項目

- [ ] `Create Production PR` ワークフローを `workflow_dispatch` で手動実行して PR が作成されること
- [ ] 作成された PR で他のワークフロー (VRT / lint / e2e など) がトリガされること

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (CI 設定のみ)

## 備考

Secret 名は本来 `GITHUB_PR_CREATE_TOKEN` として登録したかったが、GitHub 仕様で Actions Secrets は `GITHUB_` プレフィックス禁止のため `PR_CREATE_TOKEN` にした。