### PR TITLE
post: Cloudflare R2をMacOSのFinderから見られるようにしてみた

### DIFF
--- a/src/markdown/posts/20260710_1_cloudflare_r2_macos_finder.md
+++ b/src/markdown/posts/20260710_1_cloudflare_r2_macos_finder.md
@@ -1,0 +1,188 @@
+---
+title: "Cloudflare R2をMacOSのFinderから見られるようにしてみた"
+publishedAt: "2026-07-10"
+description: "Rclone の nfsmount で Cloudflare R2 バケットを macOS の Finder から読み書きできるようにした話。macFUSE 不要でセットアップできる。"
+tags: ["Cloudflare", "R2", "Rclone"]
+---
+
+こんにちは。世間は[GPT‑5.6がリリースされた](https://openai.com/ja-JP/index/previewing-gpt-5-6-sol/)ことで盛り上がっていますね。自分はまだ使っていません（契約してはいる）。
+
+
+今回はCloudflare R2とRcloneを共有フォルダとしてマウントし、MacOSのFinderから操作できるようにしてみた記事です。
+
+## TL;DR
+
+- RcloneとR2を組み合わせることにより仮想的にOSにマウントできた。 
+- MacOSにマウントしたR2のリソースをFinderで表示・操作することができた。
+- macFUSEを入れなくても `rclone nfsmount` を使えばmacOS標準のNFSクライアントでマウントできる。
+- Finderからマウントすると `.DS_Store` / `._*` がバケットに書き込まれるので、 `defaults write com.apple.desktopservices DSDontWriteNetworkStores true` で抑制しておくと良い。
+
+## 経緯（興味ある人だけどうぞ）
+
+このブログで載せる画像や動画などのメディアは基本的にバインディングされた[Cloudflare R2](https://developers.cloudflare.com/r2/)で管理していますが、これは記事執筆の障害になっていました。記事にメディアを挿入しようとする度に「画像を手元に用意し、リネームし、Exif等のファイルメタデータを消して、WranglerやWeb UIからアップロードする」という煩雑な工程を踏む必要があったためです。
+
+以前は自前でファイルアップロード用の管理画面を作って画像管理を行っていましたが、メンテが捗らず結局使わなくなってしまいました。
+
+最近ブログ投稿を再開し、記事をいくつか投稿するなかでやはりメディアの取り回しは課題だと感じたので今回紹介する方法で解決を目指しました。
+
+Finderと書いてはいるものの、Windowsやその他の大概のOSで同じようなことができるはずです。
+
+
+## Rcloneとは
+
+[Rclone](https://rclone.org/) は「rsyncのクラウド版」的なCLIツールで、S3, GCS, Azure Blob, Dropbox, Google Drive などの70種類以上のオブジェクトストレージ・クラウドストレージを共通のインターフェースで扱えるものです。Cloudflare R2はS3互換なので、Rcloneの `s3` provider として `Cloudflare` を指定するだけで使えます。
+
+そしてこのRcloneのおまけ的機能に `rclone mount` があり、これを使うとリモートストレージをローカルのファイルシステムとしてマウントできます。
+
+## macOSでどうマウントするか
+
+`rclone mount` は内部的にFUSEを利用するため、通常はmacFUSEを別途インストールする必要があります。しかしmacFUSEはkext（カーネル拡張）を要求し、System Integrity Protection（SIP）を弱める必要があるなど、個人的にはあまり入れたくないシロモノです。
+
+そこで今回は `rclone nfsmount` を使います。これはRcloneが内蔵のNFSサーバをlocalhost上に立て、それをmacOS標準のNFSクライアントからマウントするという方式で、macFUSEは不要でsudoも要りません。
+
+## セットアップ
+
+### 1. Rcloneのインストール
+
+MacOSならHomebrewで入れます。 
+
+各OSのインストール手順は以下から  
+https://rclone.org/install/
+
+```bash
+brew install rclone
+```
+
+バージョン確認。
+
+```bash
+$ rclone version
+rclone v1.74.4
+- os/version: darwin 26.3.1 (64 bit)
+- os/kernel: 25.3.0 (arm64)
+```
+
+### 2. R2のAPIトークンを発行する
+
+RcloneはS3互換API経由でR2にアクセスするため、専用のR2 APIトークンが必要です。 `wrangler` のOAuthトークンは使えないので注意。
+
+Cloudflare Dashboardから発行します:
+
+![Cloudflare Dashboard トークン一覧画面](https://cdn.sh1ma.dev/edd2e855-d360-4934-b78d-ea2597a42c3a.png)
+
+
+1. `https://dash.cloudflare.com/<account_id>/r2/api-tokens` を開く
+2. 「Create API token」を押す
+3. Permissions を `Object Read & Write` に、Bucketは対象バケットに絞る（推奨）
+4. 発行後に表示される **Access Key ID** と **Secret Access Key** を控える
+
+![Cloudflare Dashboard トークン作成後の画面](https://cdn.sh1ma.dev/fe8a13e7-d5e8-4d67-951c-644ee1201232.png)
+
+Secretは発行直後にしか表示されないので忘れずコピーしておきましょう。
+
+### 3. rclone config を書く
+
+対話モード（ `rclone config` ）でも良いのですが、値がわかっているので直接 `~/.config/rclone/rclone.conf` を書いてしまいます。
+
+```ini title="~/.config/rclone/rclone.conf"
+[sh1madev-cdn]
+type = s3
+provider = Cloudflare
+access_key_id = <ACCESS_KEY_ID>
+secret_access_key = <SECRET_ACCESS_KEY>
+region = auto
+endpoint = https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+```
+
+- `[sh1madev-cdn]` はremoteの名前（後述するマウントコマンドで使う）。任意の名前でOK。
+- `endpoint` はCloudflareダッシュボードの各バケットの「Settings」ページからも確認できる。
+- `region = auto` はR2のお約束。
+
+疎通確認:
+
+```bash
+rclone ls sh1madev-cdn:sh1madev-cdn --max-depth 1 | head
+```
+
+バケット内のオブジェクトが一覧表示されればOKです。
+
+### 4. マウントポイントを作ってマウントする
+
+```bash
+mkdir -p ~/mnt/sh1madev-cdn
+
+rclone nfsmount sh1madev-cdn:sh1madev-cdn ~/mnt/sh1madev-cdn \
+  --vfs-cache-mode writes \
+  --daemon \
+  --log-file=/tmp/rclone-sh1madev-cdn.log \
+  --log-level INFO
+```
+
+各オプションの意味:
+
+- `--vfs-cache-mode writes`: 書き込みを一度ローカルにバッファしてからR2にアップロードする。これを付けないと書き込み系の操作でエラーになりがちなので基本必須。
+- `--daemon`: バックグラウンド常駐。
+- `--log-file` / `--log-level`: 何か起きたときに切り分けるためログを吐く。
+
+マウントできたか確認:
+
+```bash
+$ mount | grep sh1madev-cdn
+localhost:/sh1madev-cdn sh1madev-cdn on /Users/sh1ma/mnt/sh1madev-cdn (nfs, nodev, nosuid, mounted by sh1ma)
+
+$ ls ~/mnt/sh1madev-cdn | head
+aaa.png
+bbb.png
+ccc.webp
+...
+```
+
+これでFinderからも `~/mnt/sh1madev-cdn` を開けば普通にR2の中身が見えます。
+
+アンマウントするときは:
+
+```bash
+umount ~/mnt/sh1madev-cdn
+```
+
+## Finderで開くときの注意: `.DS_Store` / `._*` をバケットに書き込ませない
+
+Finderで開いた瞬間にmacOSが `.DS_Store` やAppleDouble形式のリソースフォーク（ `._ファイル名` ）をせっせとバケット内に書き込みだします。
+
+自分の場合、実際にバケットの中を見たら過去の作業で汚染された痕跡が既に残っていました。
+
+```
+8196 .DS_Store
+4096 ._.DS_Store
+4096 ._128c5211dfc9d313ea1d331c388fb4008425959049fcf191138a056efa1927b9.png
+...
+```
+
+これを抑制するにはmacOSの隠しオプションを叩きます。
+
+```bash
+defaults write com.apple.desktopservices DSDontWriteNetworkStores true
+killall Finder
+```
+
+これで少なくとも `.DS_Store` は書き込まれなくなります。
+
+既に混入している分は掃除しておきましょう。 `--dry-run` を付けて対象を確認したうえで実行するのが安心。
+
+```bash
+# ドライラン
+rclone delete sh1madev-cdn:sh1madev-cdn --include ".DS_Store" --include "._*" --dry-run
+
+# 問題なければ --dry-run を外す
+rclone delete sh1madev-cdn:sh1madev-cdn --include ".DS_Store" --include "._*"
+```
+
+## セキュリティ上の注意
+
+- `~/.config/rclone/rclone.conf` にAccess Key IDとSecret Access Keyが**平文**で書かれます。心配なら `rclone config` の `--password` でconfig自体を暗号化するオプションもあるので、そちらを検討してください。
+
+## まとめ
+
+macFUSEを入れずにR2をmacOSにマウントできました。 `rclone nfsmount` は本当に便利で、これで記事執筆時のメディア取り回しが「Finderで画像コピーして貼る」だけで済むようになりました。
+
+同じ悩みを抱えている方はぜひ試してみてください。

--- a/src/markdown/posts/20260710_1_cloudflare_r2_macos_finder.md
+++ b/src/markdown/posts/20260710_1_cloudflare_r2_macos_finder.md
@@ -10,12 +10,16 @@ tags: ["Cloudflare", "R2", "Rclone"]
 
 今回はCloudflare R2とRcloneを共有フォルダとしてマウントし、MacOSのFinderから操作できるようにしてみた記事です。
 
+https://x.com/sh1ma/status/2075519775388930305?s=20
+
 ## TL;DR
 
 - RcloneとR2を組み合わせることにより仮想的にOSにマウントできた。 
 - MacOSにマウントしたR2のリソースをFinderで表示・操作することができた。
 - macFUSEを入れなくても `rclone nfsmount` を使えばmacOS標準のNFSクライアントでマウントできる。
 - Finderからマウントすると `.DS_Store` / `._*` がバケットに書き込まれるので、 `defaults write com.apple.desktopservices DSDontWriteNetworkStores true` で抑制しておくと良い。
+
+[Rclone · Cloudflare R2 docs](https://developers.cloudflare.com/r2/examples/rclone/)
 
 ## 経緯（興味ある人だけどうぞ）
 

--- a/src/markdown/posts/en/20260710_1_cloudflare_r2_macos_finder.md
+++ b/src/markdown/posts/en/20260710_1_cloudflare_r2_macos_finder.md
@@ -1,0 +1,194 @@
+---
+title: "Mounting Cloudflare R2 into macOS Finder"
+publishedAt: "2026-07-10"
+description: "How I got a Cloudflare R2 bucket to show up in macOS Finder using Rclone's nfsmount, with no macFUSE required."
+tags: ["Cloudflare", "R2", "Rclone"]
+---
+
+Hi. Everyone's talking about the [GPT‑5.6 release](https://openai.com/ja-JP/index/previewing-gpt-5-6-sol/) these days. I haven't tried it yet (though I am paying for it).
+
+
+This post is about mounting a Cloudflare R2 bucket as a shared folder with Rclone so I can use it from macOS Finder.
+
+https://x.com/sh1ma/status/2075519775388930305?s=20
+
+## TL;DR
+
+- Combining Rclone with R2, I was able to virtually mount the bucket on my OS.
+- Once mounted, I could browse and edit the R2 objects from Finder like any other folder.
+- You don't even need macFUSE: `rclone nfsmount` works with macOS's built-in NFS client.
+- When you open the mount in Finder, macOS writes `.DS_Store` / `._*` files into the bucket, so it's a good idea to suppress that with `defaults write com.apple.desktopservices DSDontWriteNetworkStores true`.
+
+[Rclone · Cloudflare R2 docs](https://developers.cloudflare.com/r2/examples/rclone/)
+
+## Background (feel free to skip)
+
+I store the images and videos for this blog in a bound [Cloudflare R2](https://developers.cloudflare.com/r2/) bucket, but that has been a friction point when writing posts. Every time I want to embed a piece of media I have to: pull the file down locally, rename it, strip EXIF and other file metadata, and then upload it via Wrangler or the web UI. Enough steps to be annoying.
+
+I used to run my own upload dashboard for image management, but I couldn't keep up with maintaining it and eventually stopped using it.
+
+Since I started posting to the blog again recently, media wrangling has felt like a real problem across the first few posts, so I decided to tackle it with the approach I describe here.
+
+Even though the title says Finder, the same thing should work on Windows and most other OSes.
+
+
+## What is Rclone?
+
+[Rclone](https://rclone.org/) is a CLI tool — think of it as "rsync for the cloud" — that talks to more than 70 object storage and cloud storage backends (S3, GCS, Azure Blob, Dropbox, Google Drive, and so on) through one consistent interface. Cloudflare R2 is S3-compatible, so all you have to do is pick the `s3` provider in Rclone and set it to `Cloudflare`.
+
+Rclone also happens to ship with `rclone mount`, which lets you mount a remote as a local filesystem.
+
+## How to mount it on macOS
+
+`rclone mount` uses FUSE under the hood, which normally means installing macFUSE. But macFUSE requires a kernel extension (kext) and asks you to weaken System Integrity Protection (SIP) — not something I personally want on my machine.
+
+Instead, I'm going to use `rclone nfsmount`. It spins up an NFS server on localhost inside Rclone and lets macOS's built-in NFS client mount it — no macFUSE, no `sudo`.
+
+## Setup
+
+I did the setup with Claude Code driving.
+
+### 1. Install Rclone
+
+On macOS, install it with Homebrew.
+
+Install instructions for other OSes are here:  
+https://rclone.org/install/
+
+```bash
+brew install rclone
+```
+
+Version check:
+
+```bash
+$ rclone version
+rclone v1.74.4
+- os/version: darwin 26.3.1 (64 bit)
+- os/kernel: 25.3.0 (arm64)
+```
+
+### 2. Create an R2 API token
+
+Rclone reaches R2 through its S3-compatible API, so you need a dedicated R2 API token. The OAuth token from `wrangler` won't work — keep that in mind.
+
+Create the token from the Cloudflare Dashboard:
+
+![Cloudflare Dashboard token list page](https://cdn.sh1ma.dev/edd2e855-d360-4934-b78d-ea2597a42c3a.png)
+
+
+1. Open `https://dash.cloudflare.com/<account_id>/r2/api-tokens`
+2. Click "Create API token"
+3. Set Permissions to `Object Read & Write`, and scope Bucket down to the target bucket (recommended)
+4. Note down the **Access Key ID** and **Secret Access Key** shown after creation
+
+![Cloudflare Dashboard screen after the token has been created](https://cdn.sh1ma.dev/fe8a13e7-d5e8-4d67-951c-644ee1201232.png)
+
+The secret is only shown once, so make sure to copy it right away.
+
+### 3. Write the rclone config
+
+You can use the interactive mode (`rclone config`), but since I already knew every value, I just wrote `~/.config/rclone/rclone.conf` by hand.
+
+```ini title="~/.config/rclone/rclone.conf"
+[sh1madev-cdn]
+type = s3
+provider = Cloudflare
+access_key_id = <ACCESS_KEY_ID>
+secret_access_key = <SECRET_ACCESS_KEY>
+region = auto
+endpoint = https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+```
+
+- `[sh1madev-cdn]` is the remote's name (used later in the mount command). Any name is fine.
+- You can find `endpoint` on each bucket's "Settings" page in the Cloudflare Dashboard as well.
+- `region = auto` is the standard for R2.
+
+Sanity check:
+
+```bash
+rclone ls sh1madev-cdn:sh1madev-cdn --max-depth 1 | head
+```
+
+If you see a list of objects from the bucket, you're good.
+
+### 4. Create a mount point and mount
+
+```bash
+mkdir -p ~/mnt/sh1madev-cdn
+
+rclone nfsmount sh1madev-cdn:sh1madev-cdn ~/mnt/sh1madev-cdn \
+  --vfs-cache-mode writes \
+  --daemon \
+  --log-file=/tmp/rclone-sh1madev-cdn.log \
+  --log-level INFO
+```
+
+What each option does:
+
+- `--vfs-cache-mode writes`: buffers writes locally before uploading to R2. Without this, most write operations tend to fail — treat it as essentially required.
+- `--daemon`: runs Rclone in the background.
+- `--log-file` / `--log-level`: writes a log so you can diagnose things when something goes wrong.
+
+Confirm it's mounted:
+
+```bash
+$ mount | grep sh1madev-cdn
+localhost:/sh1madev-cdn sh1madev-cdn on /Users/sh1ma/mnt/sh1madev-cdn (nfs, nodev, nosuid, mounted by sh1ma)
+
+$ ls ~/mnt/sh1madev-cdn | head
+aaa.png
+bbb.png
+ccc.webp
+...
+```
+
+Now you can open `~/mnt/sh1madev-cdn` in Finder and browse R2 like a normal folder.
+
+To unmount:
+
+```bash
+umount ~/mnt/sh1madev-cdn
+```
+
+## Watch out when using Finder: don't let it write `.DS_Store` / `._*` into the bucket
+
+The moment you open the mount in Finder, macOS happily starts writing `.DS_Store` files and AppleDouble resource fork files (`._<filename>`) into the bucket.
+
+In my case, I actually looked inside the bucket and found tracks left over from previous work:
+
+```
+8196 .DS_Store
+4096 ._.DS_Store
+4096 ._128c5211dfc9d313ea1d331c388fb4008425959049fcf191138a056efa1927b9.png
+...
+```
+
+To suppress this, flip a hidden macOS setting:
+
+```bash
+defaults write com.apple.desktopservices DSDontWriteNetworkStores true
+killall Finder
+```
+
+With this, at least `.DS_Store` will stop being written.
+
+You'll also want to clean up what's already leaked in. Running with `--dry-run` first lets you check the targets safely before deleting.
+
+```bash
+# Dry run
+rclone delete sh1madev-cdn:sh1madev-cdn --include ".DS_Store" --include "._*" --dry-run
+
+# Once you're happy with the list, drop --dry-run
+rclone delete sh1madev-cdn:sh1madev-cdn --include ".DS_Store" --include "._*"
+```
+
+## Security notes
+
+- The Access Key ID and Secret Access Key are stored in **plaintext** in `~/.config/rclone/rclone.conf`. If that worries you, `rclone config` also has a `--password` option that encrypts the config itself — consider using it.
+
+## Wrapping up
+
+I got R2 mounted on macOS without installing macFUSE. `rclone nfsmount` is genuinely useful, and now, when I'm writing a post, media handling is as easy as copy-pasting an image in Finder.
+
+If you've been dealing with the same annoyance, give it a try.


### PR DESCRIPTION
## 概要

Cloudflare R2 バケットを Rclone (`nfsmount`) 経由で macOS の Finder から読み書きできるようにするまでのセットアップ手順を記事にした。日本語版と英語版の両方を追加。

## 変更内容

- `src/markdown/posts/20260710_1_cloudflare_r2_macos_finder.md` を追加 (日本語)
- `src/markdown/posts/en/20260710_1_cloudflare_r2_macos_finder.md` を追加 (英語版)

## 関連Issue

なし

## テスト項目

- [ ] ローカルで記事が正しくレンダリングされる
- [ ] 日本語版・英語版どちらも公開ページからアクセスできる
- [ ] コードブロック・画像・リンクが崩れていない

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし

## 備考

なし