### PR TITLE
fix(link-card): OGP サムネの見切れを軽減する

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -91,7 +91,7 @@ body {
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease;
-  min-height: 120px;
+  min-height: 140px;
 }
 .link-card:hover {
   border-color: var(--border-brand);
@@ -140,8 +140,9 @@ body {
 }
 .link-card__thumb {
   flex: 0 0 auto;
-  width: 200px;
+  width: 260px;
   max-width: 40%;
+  aspect-ratio: 1.91 / 1;
   background: var(--bg-muted);
   display: flex;
   align-items: center;
@@ -157,8 +158,8 @@ body {
 
 @media (max-width: 640px) {
   .link-card__thumb {
-    width: 120px;
-    max-width: 35%;
+    width: 140px;
+    max-width: 38%;
   }
 }
 


### PR DESCRIPTION
## 概要

記事本文に埋め込まれる link-card (OGP プレビュー) のサムネイル画像が、`object-fit: cover` によって左右が大きくトリミングされ「はみ出しているように見える」問題を修正した。合わせてサムネが少し小さかったので拡大している。

## 変更内容

- `src/globals.css`
  - `.link-card__thumb` の幅を 200px → **260px** (mobile: 120px → 140px) に拡大
  - `.link-card__thumb` に `aspect-ratio: 1.91 / 1` (OGP 標準比) を付与し、GitHub 等の 1200×600 系画像が横方向にトリミングされにくくした
  - `.link-card` の `min-height` を 120px → 140px に微調整

## 関連Issue

なし

## テスト項目

- [x] ローカル dev で GitHub / Cloudflare Blog の OGP カードが以前より見切れずに表示されることを確認
- [x] `pnpm check` が pass (既存の警告は本 PR と無関係)
- [x] `pnpm typecheck` が pass
- [ ] VRT の差分が意図通り (link-card を含むページの見た目差分のみ)

## VRT設定

- [x] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

**Before (desktop)**
`dev-assets/card-before.png` — GitHub OGP の "cloudflare/agentic-inbox" の "cl" が切れている。

**After (desktop)**
`dev-assets/card-after.png` — 文字が収まり、Cloudflare ロゴも見える。

**After (mobile)**
`dev-assets/card-mobile.png`

## 備考

`aspect-ratio` は flex `align-items: stretch` + カード min-height の影響で本文が長い場合は完全には効かず、その場合は従来と同じく高さがカードにフィットする。あくまで「サムネが本文より短くなる場合」に OGP 比率で表示するための保険。