### PR TITLE
fix: フッターの Google Analytics 文言を英語ページで英語表示にする

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,7 +1,10 @@
+import { useLocation } from "@tanstack/react-router"
 import { Github, PenLine, Rss } from "lucide-react"
 
 export const Footer = () => {
   const currentYear = new Date().getFullYear()
+  const { pathname } = useLocation()
+  const isEnglish = pathname === "/en" || pathname.startsWith("/en/")
 
   return (
     <footer className="border-t border-gray-200 bg-bg-surface">
@@ -18,8 +21,13 @@ export const Footer = () => {
           <p className="text-sm text-text-muted">
             © {currentYear} sh1ma. All rights reserved.
           </p>
-          <p className="mt-2 text-xs text-text-muted">
-            このサイトはアクセス解析のため Google Analytics を利用しています。
+          <p
+            className="mt-2 text-xs text-text-muted"
+            lang={isEnglish ? "en" : "ja"}
+          >
+            {isEnglish
+              ? "This site uses Google Analytics for access analytics."
+              : "このサイトはアクセス解析のため Google Analytics を利用しています。"}
           </p>
         </div>
 


### PR DESCRIPTION
## 概要

英語ページ (`/en` 配下) のフッターに表示される Google Analytics 利用の告知文が日本語のままだったので、英語で表示するようにした。

## 変更内容

- `src/components/Footer/Footer.tsx` で `useLocation` を使い、`pathname` が `/en` もしくは `/en/` で始まる場合を英語版と判定
- 英語版では "This site uses Google Analytics for access analytics." を表示し、`lang` 属性も `en`/`ja` を切り替え

## 関連Issue

なし

## テスト項目

- [ ] `/` のフッターに従来どおり日本語の告知文が表示される
- [ ] `/en` のフッターに英語の告知文が表示される
- [ ] `/en/articles/*` のフッターに英語の告知文が表示される

## VRT設定

- [x] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

## 備考

英語版判定ロジックは `BlogHeader.tsx` の `isEnglish` と同じ形にしている。