### PR TITLE
post: Cloudflare Containersを使ってGitHub Self-hosted runnersを立ててみた

### DIFF
--- a/src/markdown/posts/20260720_1_cloudflare_containers_github_self_hosted_runners.md
+++ b/src/markdown/posts/20260720_1_cloudflare_containers_github_self_hosted_runners.md
@@ -1,0 +1,239 @@
+---
+title: "Cloudflare Containersを使ってGitHub Self-hosted runnersを立ててみた"
+publishedAt: "2026-07-20"
+description: "Cloudflare Containers 上に GitHub Actions のエフェメラル self-hosted runner を webhook 駆動で立てて、実測とともに GitHub-hosted runner との料金比較をしてみた。"
+tags: ["Cloudflare", "Cloudflare Containers", "GitHub Actions"]
+---
+
+本当は昨日CADモデリング + 3Dプリンタ操作をClaude Codeでやる記事を出す予定だったんですが、モデリング部分が記事として出せるクオリティに至らなかったのでもう少し研究してから出そうと思います・・・！[^1]
+
+というわけで今回も繋ぎの[Cloudflare Containers](https://developers.cloudflare.com/containers/)ネタです。
+
+今回はCloudflare Containersの上で[GitHub ActionsのSelf-Hosted Runner](https://docs.github.com/en/actions/concepts/runners/self-hosted-runners) を動かしてみたので、やり方紹介と料金ざっくり比較記事です。
+
+前半はGitHub ActionsのSelf-Hosted Runner解説なので知ってるよって人はスキップしてOK。
+
+## TL;DR
+
+- Cloudflare Containersを使ってGitHub ActionsのSelf-Hosted Runnerを立てた
+- 大抵の場面でSelf-Hosted Runner on Cloudflare Containersに料金・スペックの優位性はないことがわかった。
+- とはいえCloudflare Containersは使用したリソース分のみ課金なので、すでにWorkersのPaid Plan（現在$5/月）を契約していて、かつ短時間・小リソースのジョブを大量に回すなら一考の余地はあるかも。
+
+## GitHub ActionsのSelf-Hosted Runnerって？
+
+ActionsをGitHubのサーバで実行するのではなく、自分で用意したマシンで実行する仕組みです。  
+ここでは詳細を割愛しますが、以下を見ると理解できると思います。
+
+https://docs.github.com/en/actions/concepts/runners/self-hosted-runners
+
+Self-Hosted Runnerを立ち上げること作業は特に難しくありません。  
+とはいえPersistent runnerとEphemeral runnerで微妙に立ち上げ方や運用方法が異なります。
+
+### Persistent runnerとEphemeral runnerとは
+
+簡単に言うとPersitent runnerは常駐式のRunnerで、常駐コンテナが必要です。  
+それに対してEphemeral runnerはGithub Actionsのジョブが開始されるたびに起動するRunnerです。こちらはリクエスト処理時にのみコンテナが立ち上がります。
+
+https://github.blog/changelog/2021-09-20-github-actions-ephemeral-self-hosted-runners-new-webhooks-for-auto-scaling/
+
+https://docs.github.com/en/actions/reference/runners/self-hosted-runners#ephemeral-runners-for-autoscaling
+
+せっかくなら動かした結果「CloudflareでSelf-Hosted Runner動かす方が安い！」という結論になれば面白いと思ったのですが、以前[k3sをCloudflare Containersで動かした](https://blog.sh1ma.dev/articles/20260705_k3s_on_cloudflare_workers)際に常駐が必要なコンテナは、Container自体が消費するメモリ使用量が原因で、基本的には他のプラットフォームに対して優位に立てる料金ではないという結論が出ています。[^2]
+
+つまり今回Cloudflare ContainersがGitHub Hosted Runnerに勝つ可能性があるとしたら、常駐の必要がなく、ジョブ発火時のみ動作するEphemeral runnerになります。
+
+## スペック比較: Github Hosted Runner VS Cloudflare Containers Runner
+
+- GitHub は使用の有無にかかわらず 2 コア 8GB の固定単価
+- Cloudflare ContainersのCPUは実使用量課金。
+
+| 実行環境 | vCPU | メモリ | ディスク | 備考 |
+|---|---|---|---|---|
+| GitHub `ubuntu-latest` (private) | 2 | 8 GB | 14 GB SSD | $0.006/分・分単位切り上げ |
+| GitHub `ubuntu-latest` (public) | 4 | 16 GB | 14 GB SSD | **無料・無制限** |
+| CF lite | 1/16 | 256 MiB | 2 GB | 動作確認済み（遅い） |
+| CF basic | 1/4 | 1 GiB | 4 GB | 動作確認済み・推奨最小構成 |
+| CF standard-1 | 1/2 | 4 GiB | 8 GB | |
+| CF standard-2 | 1 | 6 GiB | 12 GB | |
+| CF standard-3 | 2 | 8 GiB | 16 GB | private `ubuntu-latest` とスペック同等 |
+| CF standard-4 | 4 | 12 GiB | 20 GB | public 用 (4コア/16GB) にはメモリで届かない |
+
+https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+
+https://docs.github.com/en/billing/reference/actions-runner-pricing
+
+https://developers.cloudflare.com/containers/pricing/
+
+https://developers.cloudflare.com/workers/platform/pricing/#containers
+
+
+## 実装
+
+### Worker
+
+Worker は `workflow_job` webhook (action: `queued`) を受けたら、registration token を発行して Container (Durable Object) を起動するだけの薄い実装です。
+
+```typescript
+if (url.pathname === "/webhook" && request.method === "POST") {
+  const body = await request.text();
+  const ok = await verifySignature(
+    env.WEBHOOK_SECRET,
+    body,
+    request.headers.get("x-hub-signature-256"),
+  );
+  if (!ok) return new Response("bad signature", { status: 401 });
+
+  // workflow_job / queued / 対象 label 以外は無視 (省略)
+
+  const token = await getRegistrationToken(env);
+  const name = `cf-runner-${payload.workflow_job.id}`;
+  const container = env.RUNNER.getByName(name);
+  await container.launch({
+    repoUrl: `https://github.com/${env.GITHUB_REPO}`,
+    token,
+    labels: env.RUNNER_LABEL,
+    name,
+  });
+  return new Response("launched");
+}
+```
+
+Container 側は `@cloudflare/containers` の `Container` クラスを継承します。runner は HTTP を提供しないバッチプロセスなので `defaultPort` は設定せず、`sleepAfter` はジョブがハングしたときの課金上限のセーフティキャップとして使います。
+
+```typescript
+export class RunnerContainer extends Container<Env> {
+  sleepAfter = "15m";
+
+  async launch(opts: { repoUrl: string; token: string; labels: string; name: string }) {
+    await this.start({
+      envVars: {
+        REPO_URL: opts.repoUrl,
+        RUNNER_TOKEN: opts.token,
+        RUNNER_LABELS: opts.labels,
+        RUNNER_NAME: opts.name,
+      },
+    });
+  }
+}
+```
+
+### コンテナイメージ
+
+イメージは ubuntu:24.04 に actions/runner を入れただけの素朴なものです。
+
+https://github.com/actions/runner/releases
+
+```dockerfile
+FROM ubuntu:24.04
+
+ARG RUNNER_VERSION=2.335.1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates curl jq git tar gzip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /runner
+
+RUN curl -fL -o runner.tar.gz \
+      "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+    && tar xzf runner.tar.gz \
+    && rm runner.tar.gz \
+    && ./bin/installdependencies.sh
+
+COPY entrypoint.sh /entrypoint.sh
+ENV RUNNER_ALLOW_RUNASROOT=1
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+entrypoint は `--ephemeral` で config して run するだけです。
+
+```bash
+./config.sh \
+  --unattended \
+  --ephemeral \
+  --disableupdate \
+  --url "${REPO_URL}" \
+  --token "${RUNNER_TOKEN}" \
+  --name "${RUNNER_NAME}" \
+  --labels "${RUNNER_LABELS}"
+
+exec ./run.sh
+```
+
+### ワークフロー側
+
+ワークフローは `runs-on` に self-hosted と runner の label を指定するだけです。
+
+```yaml
+jobs:
+  hello:
+    runs-on: [self-hosted, cf-runner]
+```
+
+## 動いた
+
+実ジョブ (echo + checkout) が成功しました。中身は Firecracker microVM で、`uname -a` すると `Linux cloudchamber 6.18.36-cloudflare-firecracker` (linux/amd64) が返ります。
+
+実測値はこうなりました。
+
+| 項目 | basic (1/4 vCPU, 1GiB) | lite (1/16 vCPU, 256MiB) |
+|---|---|---|
+| ジョブ結果 | success | success |
+| webhook 受信 → ジョブ開始 | 約 11 秒 | 約 13 秒 |
+| ジョブ実行時間 | 23 秒 | 74 秒 |
+| 1 ジョブあたり概算コスト | ≈ $0.00018 | ≈ $0.00015 |
+
+キュー投入からジョブ開始まで、コールドスタート込みで約 11〜13 秒。GitHub-hosted runner の起動待ちと同じくらいの感覚です。
+
+### lite は安くならない
+
+面白かったのがここです。lite は単価が basic の約 1/3.9 なのですが、1/16 vCPU しかないので同じジョブに約 3.2 倍の時間がかかり、**「単価 × 実行時間」のジョブ単価はほぼ同じ**になりました。レイテンシの分だけ損なので、実用的な最小構成は basic だと思います。
+
+もうひとつハマりどころ。インスタンスタイプの変更は即時反映ではないので、`wrangler containers info` で configuration の反映を確認してから計測しないと旧スペックのインスタンスで実行されます。
+
+## 料金比較
+
+前提となる公式単価はこうです (2026-07-20 時点)。
+
+- **Cloudflare Containers** (Workers Paid $5/月 が前提): vCPU $0.000020/vCPU秒、メモリ $0.0000025/GiB秒、ディスク $0.00000007/GB秒。**秒課金・実行中のみ**。無料枠は 375 vCPU分、25 GiB時、200 GB時/月
+- **GitHub Actions** (hosted、private リポジトリ): Linux 2コア $0.006/分。**ジョブごとに分単位へ切り上げ**。無料枠は Free 2,000分/月、Pro/Team 3,000分/月。public リポジトリは無料・無制限
+
+インスタンスタイプ別に $/分 へ換算して比較すると次のようになります。
+
+| CF インスタンス | スペック | $/分 | GitHub 2コア ($0.006/分) 比 |
+|---|---|---|---|
+| lite | 1/16 vCPU, 256MiB | $0.000121 | 約 1/50 |
+| basic | 1/4 vCPU, 1GiB | $0.000467 | 約 1/13 |
+| standard-1 | 1/2 vCPU, 4GiB | $0.001234 | 約 1/4.9 |
+| standard-3 | 2 vCPU, 8GiB | $0.003667 | 約 1/1.6 |
+
+GitHub の ubuntu-latest (private) は 2 vCPU / 8GB RAM なので、スペック同等の比較対象は standard-3。それでも **CF の方が約 39% 安い**うえ、CF は秒課金・GitHub は分切り上げなので、短いジョブほど差が広がります。
+
+### CF Containers が優位になるケース
+
+1. **private リポジトリで無料枠を使い切っている**: 超過分は同等スペックで約 39% 安。軽いジョブを basic に落とせれば 1/13
+2. **短時間ジョブが大量にある**: GitHub は 1 分に切り上げるので、10 秒のジョブ 1,000 本なら GitHub $6.00 vs CF basic 約 $0.08 で約 75 倍差
+3. **低スペックで足りるジョブ** (lint、通知など)
+4. **Workers Paid を既に契約している**: 無料枠 375 vCPU分/月で basic 相当 1,500 分/月が追加費用ゼロ
+
+### GitHub-hosted のままでいいケース
+
+1. **public リポジトリ**: hosted runner が無料・無制限なので勝ち目なし
+2. **無料枠 (2,000分/月) 以内の利用**: GitHub $0 に対して CF は Workers Paid $5/月 の固定費で負ける
+3. **Docker が必要なジョブ**: Firecracker microVM 内でネスト仮想化ができず docker daemon が動かないので、コンテナビルド系 CI は不向き
+4. **プリインストールツール前提のジョブ**: hosted runner の膨大なツールチェーンはないので、セットアップ時間がそのまま課金時間になる
+
+損益分岐の目安は、**GitHub の無料枠を使い切ったうえで月 1,500〜2,000 分以上**使うなら CF が安くなる、というあたりです。
+
+## まとめ
+
+- Cloudflare Containers 上で GitHub Actions の self-hosted runner は普通に動く
+- webhook 駆動 + `--ephemeral` で「ジョブが来たときだけ課金」にできる
+- lite は安く見えて遅いのでジョブ単価は basic とほぼ同じ。basic が実用最小構成
+- private リポジトリで無料枠を使い切る規模 (月 1,500〜2,000 分以上) なら GitHub-hosted より安い。public リポジトリや Docker ビルド前提の CI には向かない
+
+
+
+[^1]:https://x.com/sh1ma/status/2078146772367720493
+[^2]:https://x.com/sh1ma/status/2072666550436556888

--- a/src/markdown/posts/20260720_1_cloudflare_containers_github_self_hosted_runners.md
+++ b/src/markdown/posts/20260720_1_cloudflare_containers_github_self_hosted_runners.md
@@ -17,7 +17,7 @@ tags: ["Cloudflare", "Cloudflare Containers", "GitHub Actions"]
 
 - Cloudflare Containersを使ってGitHub ActionsのSelf-Hosted Runnerを立てた
 - 大抵の場面でSelf-Hosted Runner on Cloudflare Containersに料金・スペックの優位性はないことがわかった。
-- とはいえCloudflare Containersは使用したリソース分のみ課金なので、すでにWorkersのPaid Plan（現在$5/月）を契約していて、かつ短時間・小リソースのジョブを大量に回すなら一考の余地はあるかも。
+- とはいえCloudflare Containersは使用したリソース分のみ課金なので、すでにWorkersのPaid Plan（現在\$5/月）を契約していて、かつ短時間・小リソースのジョブを大量に回すなら一考の余地はあるかも。
 
 ## GitHub ActionsのSelf-Hosted Runnerって？
 
@@ -49,7 +49,7 @@ https://docs.github.com/en/actions/reference/runners/self-hosted-runners#ephemer
 
 | 実行環境 | vCPU | メモリ | ディスク | 備考 |
 |---|---|---|---|---|
-| GitHub `ubuntu-latest` (private) | 2 | 8 GB | 14 GB SSD | $0.006/分・分単位切り上げ |
+| GitHub `ubuntu-latest` (private) | 2 | 8 GB | 14 GB SSD | \$0.006/分・分単位切り上げ |
 | GitHub `ubuntu-latest` (public) | 4 | 16 GB | 14 GB SSD | **無料・無制限** |
 | CF lite | 1/16 | 256 MiB | 2 GB | 動作確認済み（遅い） |
 | CF basic | 1/4 | 1 GiB | 4 GB | 動作確認済み・推奨最小構成 |
@@ -182,7 +182,7 @@ jobs:
 | ジョブ結果 | success | success |
 | webhook 受信 → ジョブ開始 | 約 11 秒 | 約 13 秒 |
 | ジョブ実行時間 | 23 秒 | 74 秒 |
-| 1 ジョブあたり概算コスト | ≈ $0.00018 | ≈ $0.00015 |
+| 1 ジョブあたり概算コスト | ≈ \$0.00018 | ≈ \$0.00015 |
 
 キュー投入からジョブ開始まで、コールドスタート込みで約 11〜13 秒。GitHub-hosted runner の起動待ちと同じくらいの感覚です。
 
@@ -196,42 +196,56 @@ jobs:
 
 前提となる公式単価はこうです (2026-07-20 時点)。
 
-- **Cloudflare Containers** (Workers Paid $5/月 が前提): vCPU $0.000020/vCPU秒、メモリ $0.0000025/GiB秒、ディスク $0.00000007/GB秒。**秒課金・実行中のみ**。無料枠は 375 vCPU分、25 GiB時、200 GB時/月
-- **GitHub Actions** (hosted、private リポジトリ): Linux 2コア $0.006/分。**ジョブごとに分単位へ切り上げ**。無料枠は Free 2,000分/月、Pro/Team 3,000分/月。public リポジトリは無料・無制限
+- **Cloudflare Containers** (Workers Paid \$5/月 が前提): vCPU \$0.000020/vCPU秒、メモリ \$0.0000025/GiB秒、ディスク \$0.00000007/GB秒。**10ms 単位課金・実行中のみ**。無料枠は 375 vCPU分、25 GiB時、200 GB時/月
+- **GitHub Actions** (hosted、private リポジトリ): Linux 2コア \$0.006/分。**ジョブごとに分単位へ切り上げ**。無料枠は Free 2,000分/月、Pro/Team 3,000分/月。public リポジトリは無料・無制限
 
-インスタンスタイプ別に $/分 へ換算して比較すると次のようになります。
+ここで効いてくるのが [2025-11-21 の料金改定](https://developers.cloudflare.com/changelog/post/2025-11-21-new-cpu-pricing/)です。CPU 課金は割当 vCPU ではなく**実際の CPU 使用量ベース**に変わっています (メモリとディスクは従来どおり割当ベース)。つまり CPU をフルに使わないジョブほど安くなります。
 
-| CF インスタンス | スペック | $/分 | GitHub 2コア ($0.006/分) 比 |
-|---|---|---|---|
-| lite | 1/16 vCPU, 256MiB | $0.000121 | 約 1/50 |
-| basic | 1/4 vCPU, 1GiB | $0.000467 | 約 1/13 |
-| standard-1 | 1/2 vCPU, 4GiB | $0.001234 | 約 1/4.9 |
-| standard-3 | 2 vCPU, 8GiB | $0.003667 | 約 1/1.6 |
+インスタンスタイプ別に \$/分 へ換算して比較すると次のようになります。CPU 100% の列が上限値で、実コストはこれ以下になります。
 
-GitHub の ubuntu-latest (private) は 2 vCPU / 8GB RAM なので、スペック同等の比較対象は standard-3。それでも **CF の方が約 39% 安い**うえ、CF は秒課金・GitHub は分切り上げなので、短いジョブほど差が広がります。
+| CF インスタンス | スペック | \$/分 (CPU100%) | \$/分 (CPU20%) | GitHub 2コア (\$0.006/分) 比 |
+|---|---|---|---|---|
+| lite | 1/16 vCPU, 256MiB | \$0.000121 | \$0.000061 | 約 1/50〜1/98 |
+| basic | 1/4 vCPU, 1GiB | \$0.000467 | \$0.000227 | 約 1/13〜1/26 |
+| standard-1 | 1/2 vCPU, 4GiB | \$0.001234 | \$0.000754 | 約 1/4.9〜1/8.0 |
+| standard-3 | 2 vCPU, 8GiB | \$0.003667 | \$0.001747 | 約 1/1.6〜1/3.4 |
+
+GitHub の ubuntu-latest (private) は 2 vCPU / 8GB RAM なので、スペック同等の比較対象は standard-3。CPU をフルに使うビルドでも **CF の方が約 39% 安く**、I/O 待ち中心で CPU 使用率 20% 程度のジョブなら**約 71% 安い**。さらに CF は 10ms 単位課金・GitHub は分切り上げなので、短いジョブほど差が広がります。
 
 ### CF Containers が優位になるケース
 
-1. **private リポジトリで無料枠を使い切っている**: 超過分は同等スペックで約 39% 安。軽いジョブを basic に落とせれば 1/13
-2. **短時間ジョブが大量にある**: GitHub は 1 分に切り上げるので、10 秒のジョブ 1,000 本なら GitHub $6.00 vs CF basic 約 $0.08 で約 75 倍差
+1. **private リポジトリで無料枠を使い切っている**: 超過分は同等スペックで 39〜71% 安。軽いジョブを basic に落とせれば 1/13〜1/26
+2. **短時間ジョブが大量にある**: GitHub は 1 分に切り上げるので、10 秒のジョブ 1,000 本なら GitHub \$6.00 vs CF basic 約 \$0.08 で約 75 倍差
 3. **低スペックで足りるジョブ** (lint、通知など)
 4. **Workers Paid を既に契約している**: 無料枠 375 vCPU分/月で basic 相当 1,500 分/月が追加費用ゼロ
 
 ### GitHub-hosted のままでいいケース
 
 1. **public リポジトリ**: hosted runner が無料・無制限なので勝ち目なし
-2. **無料枠 (2,000分/月) 以内の利用**: GitHub $0 に対して CF は Workers Paid $5/月 の固定費で負ける
+2. **無料枠 (2,000分/月) 以内の利用**: GitHub \$0 に対して CF は Workers Paid \$5/月 の固定費で負ける
 3. **Docker が必要なジョブ**: Firecracker microVM 内でネスト仮想化ができず docker daemon が動かないので、コンテナビルド系 CI は不向き
 4. **プリインストールツール前提のジョブ**: hosted runner の膨大なツールチェーンはないので、セットアップ時間がそのまま課金時間になる
 
-損益分岐の目安は、**GitHub の無料枠を使い切ったうえで月 1,500〜2,000 分以上**使うなら CF が安くなる、というあたりです。
+### 損益分岐
+
+損益分岐は前提の置き方で 2 通りあります。
+
+1. **単一アカウントの総額で比較する場合** (GitHub Free の無料枠 2,000 分が丸ごと使える場合): GitHub は 2,000 分まで \$0、CF は \$5/月の固定費から始まるので、逆転は **CPU 100% のジョブで約 6,980 分/月、CPU 20% のジョブで約 3,830 分/月** (standard-3、両者の無料枠込みで計算)
+2. **限界費用で比較する場合** (無料枠を他のワークロードで消化済み・Workers Paid 契約済みの場合): 1 分あたり GitHub \$0.006 vs CF standard-3 \$0.00367 (CPU100%)〜\$0.00175 (CPU20%) なので、**使った瞬間から CF が 39〜71% 安い**
+
+![月間 CI 使用量と月額料金の比較グラフ。GitHub Free は無料枠 2,000 分を超えると傾き \$0.006/分で増え、Cloudflare standard-3 は \$5/月の固定費から始まる。交点 (損益分岐) は CPU 100% で約 6,980 分/月、CPU 20% で約 3,830 分/月](https://cdn.sh1ma.dev/20260720_1_cloudflare_containers_github_self_hosted_runners/ci-cost-vs-usage.ja.png)
+
+総額ベースでワークロード別に置いてみると、無料枠に収まる少量利用 (1,000 分/月) では GitHub \$0 vs CF \$5〜 で GitHub の勝ち、3,000 分/月でもまだ GitHub の勝ち (\$6.00 vs \$15.28)、10,000 分/月の規模になると CF が逆転 (\$48.00 vs \$40.95)、という結果になりました。CPU 使用率が低いジョブならさらに差が開きます。
+
+![ワークロード別の月額総額比較の棒グラフ。無料枠と固定費を織り込んだ総額で、1,000 分/月と 3,000 分/月は GitHub が安く、10,000 分/月で Cloudflare が逆転する](https://cdn.sh1ma.dev/20260720_1_cloudflare_containers_github_self_hosted_runners/ci-cost-cases.ja.png)
 
 ## まとめ
 
 - Cloudflare Containers 上で GitHub Actions の self-hosted runner は普通に動く
 - webhook 駆動 + `--ephemeral` で「ジョブが来たときだけ課金」にできる
 - lite は安く見えて遅いのでジョブ単価は basic とほぼ同じ。basic が実用最小構成
-- private リポジトリで無料枠を使い切る規模 (月 1,500〜2,000 分以上) なら GitHub-hosted より安い。public リポジトリや Docker ビルド前提の CI には向かない
+- 2025-11 から CPU は実使用量課金なので、CPU を持て余すジョブほど安い (同等スペック比で 39〜71% 安)
+- ただし総額で見ると、GitHub の無料枠と Workers Paid \$5/月 が効くので、逆転するのは月 4,000〜7,000 分規模から。public リポジトリや Docker ビルド前提の CI には向かない
 
 
 

--- a/src/markdown/posts/en/20260720_1_cloudflare_containers_github_self_hosted_runners.md
+++ b/src/markdown/posts/en/20260720_1_cloudflare_containers_github_self_hosted_runners.md
@@ -1,0 +1,253 @@
+---
+title: "Running GitHub Self-hosted Runners on Cloudflare Containers"
+publishedAt: "2026-07-20"
+description: "I set up ephemeral GitHub Actions self-hosted runners on Cloudflare Containers, driven by webhooks, and compared the cost against GitHub-hosted runners with real measurements."
+tags: ["Cloudflare", "Cloudflare Containers", "GitHub Actions"]
+---
+
+I was actually planning to publish an article yesterday about doing CAD modeling and 3D printer control with Claude Code, but the modeling part didn't reach a quality I'd be happy publishing, so I'll do a bit more research first...![^1]
+
+So this is another stopgap [Cloudflare Containers](https://developers.cloudflare.com/containers/) post.
+
+This time I got a [GitHub Actions self-hosted runner](https://docs.github.com/en/actions/concepts/runners/self-hosted-runners) running on Cloudflare Containers, so this article covers how to do it, plus a rough cost comparison.
+
+The first half is an intro to GitHub Actions self-hosted runners, so feel free to skip it if you already know the topic.
+
+## TL;DR
+
+- I set up a GitHub Actions self-hosted runner on Cloudflare Containers.
+- In most scenarios, a self-hosted runner on Cloudflare Containers has no cost or spec advantage.
+- That said, Cloudflare Containers only bills for the resources you actually use, so if you're already on the Workers Paid plan (currently \$5/month) and you run lots of short, low-resource jobs, it might be worth considering.
+
+## What's a GitHub Actions self-hosted runner?
+
+It's a mechanism for running Actions on machines you provide yourself, instead of on GitHub's servers.  
+I'll skip the details here — the docs below explain it well.
+
+https://docs.github.com/en/actions/concepts/runners/self-hosted-runners
+
+Setting up a self-hosted runner isn't particularly hard.  
+However, persistent runners and ephemeral runners differ slightly in how you set them up and operate them.
+
+### Persistent runners vs ephemeral runners
+
+In short, a persistent runner is an always-on runner that requires a long-running container.  
+An ephemeral runner, on the other hand, starts up each time a GitHub Actions job begins — the container only comes up while there's work to do.
+
+https://github.blog/changelog/2021-09-20-github-actions-ephemeral-self-hosted-runners-new-webhooks-for-auto-scaling/
+
+https://docs.github.com/en/actions/reference/runners/self-hosted-runners#ephemeral-runners-for-autoscaling
+
+It would have been fun if this experiment ended with "running self-hosted runners on Cloudflare is cheaper!", but when I [ran k3s on Cloudflare Containers](https://blog.sh1ma.dev/en/articles/20260705_k3s_on_cloudflare_workers) a while back, I already concluded that containers that need to stay running generally can't compete on price with other platforms, because of the memory the container itself consumes.[^2]
+
+So if Cloudflare Containers has any chance of beating GitHub-hosted runners, it's with ephemeral runners, which don't need to stay resident and only run when a job fires.
+
+## Spec comparison: GitHub-hosted runners vs Cloudflare Containers runners
+
+- GitHub charges a fixed per-minute rate for 2 cores / 8 GB, whether you use them or not.
+- Cloudflare Containers bills CPU by actual usage.
+
+| Environment | vCPU | Memory | Disk | Notes |
+|---|---|---|---|---|
+| GitHub `ubuntu-latest` (private) | 2 | 8 GB | 14 GB SSD | \$0.006/min, rounded up per minute |
+| GitHub `ubuntu-latest` (public) | 4 | 16 GB | 14 GB SSD | **free, unlimited** |
+| CF lite | 1/16 | 256 MiB | 2 GB | verified working (slow) |
+| CF basic | 1/4 | 1 GiB | 4 GB | verified working, recommended minimum |
+| CF standard-1 | 1/2 | 4 GiB | 8 GB | |
+| CF standard-2 | 1 | 6 GiB | 12 GB | |
+| CF standard-3 | 2 | 8 GiB | 16 GB | spec-equivalent to private `ubuntu-latest` |
+| CF standard-4 | 4 | 12 GiB | 20 GB | falls short of the public runner (4 cores/16 GB) on memory |
+
+https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+
+https://docs.github.com/en/billing/reference/actions-runner-pricing
+
+https://developers.cloudflare.com/containers/pricing/
+
+https://developers.cloudflare.com/workers/platform/pricing/#containers
+
+
+## Implementation
+
+### Worker
+
+The Worker is a thin layer: when it receives a `workflow_job` webhook (action: `queued`), it issues a registration token and starts a Container (Durable Object).
+
+```typescript
+if (url.pathname === "/webhook" && request.method === "POST") {
+  const body = await request.text();
+  const ok = await verifySignature(
+    env.WEBHOOK_SECRET,
+    body,
+    request.headers.get("x-hub-signature-256"),
+  );
+  if (!ok) return new Response("bad signature", { status: 401 });
+
+  // Ignore anything that isn't workflow_job / queued / the target label (omitted)
+
+  const token = await getRegistrationToken(env);
+  const name = `cf-runner-${payload.workflow_job.id}`;
+  const container = env.RUNNER.getByName(name);
+  await container.launch({
+    repoUrl: `https://github.com/${env.GITHUB_REPO}`,
+    token,
+    labels: env.RUNNER_LABEL,
+    name,
+  });
+  return new Response("launched");
+}
+```
+
+The container side extends the `Container` class from `@cloudflare/containers`. Since the runner is a batch process that doesn't serve HTTP, there's no `defaultPort`, and `sleepAfter` acts as a safety cap on billing in case a job hangs.
+
+```typescript
+export class RunnerContainer extends Container<Env> {
+  sleepAfter = "15m";
+
+  async launch(opts: { repoUrl: string; token: string; labels: string; name: string }) {
+    await this.start({
+      envVars: {
+        REPO_URL: opts.repoUrl,
+        RUNNER_TOKEN: opts.token,
+        RUNNER_LABELS: opts.labels,
+        RUNNER_NAME: opts.name,
+      },
+    });
+  }
+}
+```
+
+### Container image
+
+The image is nothing fancy — just ubuntu:24.04 with actions/runner installed.
+
+https://github.com/actions/runner/releases
+
+```dockerfile
+FROM ubuntu:24.04
+
+ARG RUNNER_VERSION=2.335.1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates curl jq git tar gzip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /runner
+
+RUN curl -fL -o runner.tar.gz \
+      "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+    && tar xzf runner.tar.gz \
+    && rm runner.tar.gz \
+    && ./bin/installdependencies.sh
+
+COPY entrypoint.sh /entrypoint.sh
+ENV RUNNER_ALLOW_RUNASROOT=1
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+The entrypoint just runs config with `--ephemeral` and then starts the runner.
+
+```bash
+./config.sh \
+  --unattended \
+  --ephemeral \
+  --disableupdate \
+  --url "${REPO_URL}" \
+  --token "${RUNNER_TOKEN}" \
+  --name "${RUNNER_NAME}" \
+  --labels "${RUNNER_LABELS}"
+
+exec ./run.sh
+```
+
+### Workflow side
+
+In the workflow, all you do is specify `self-hosted` and the runner's label in `runs-on`.
+
+```yaml
+jobs:
+  hello:
+    runs-on: [self-hosted, cf-runner]
+```
+
+## It works
+
+A real job (echo + checkout) succeeded. Under the hood it's a Firecracker microVM — `uname -a` returns `Linux cloudchamber 6.18.36-cloudflare-firecracker` (linux/amd64).
+
+Here are the measurements:
+
+| Item | basic (1/4 vCPU, 1GiB) | lite (1/16 vCPU, 256MiB) |
+|---|---|---|
+| Job result | success | success |
+| Webhook received → job start | ~11 s | ~13 s |
+| Job duration | 23 s | 74 s |
+| Approx. cost per job | ≈ \$0.00018 | ≈ \$0.00015 |
+
+From queueing to job start takes about 11–13 seconds including the cold start — roughly the same as waiting for a GitHub-hosted runner to spin up.
+
+### lite doesn't actually save money
+
+This was the interesting part. lite's unit price is about 1/3.9 of basic's, but with only 1/16 vCPU the same job takes about 3.2× longer, so the **per-job cost (unit price × duration) comes out nearly identical**. You just lose on latency, so I'd say basic is the practical minimum configuration.
+
+One more gotcha: instance type changes don't roll out immediately. If you don't confirm the configuration has propagated with `wrangler containers info` before measuring, your job runs on an instance with the old spec.
+
+## Cost comparison
+
+Here are the official rates this is based on (as of 2026-07-20):
+
+- **Cloudflare Containers** (requires Workers Paid, \$5/month): vCPU \$0.000020/vCPU-second, memory \$0.0000025/GiB-second, disk \$0.00000007/GB-second. **Billed in 10ms increments, only while running.** Included allowance: 375 vCPU-minutes, 25 GiB-hours, 200 GB-hours per month.
+- **GitHub Actions** (hosted, private repositories): Linux 2-core at \$0.006/min, **rounded up to the minute per job**. Free tier: 2,000 min/month on Free, 3,000 min/month on Pro/Team. Public repositories are free and unlimited.
+
+The thing that really matters here is the [pricing change from 2025-11-21](https://developers.cloudflare.com/changelog/post/2025-11-21-new-cpu-pricing/): CPU is now billed by **actual CPU usage** rather than allocated vCPU (memory and disk are still allocation-based). In other words, the less CPU your job actually uses, the cheaper it gets.
+
+Converted to \$/min per instance type, the comparison looks like this. The CPU 100% column is the upper bound — real costs come in below it.
+
+| CF instance | Spec | \$/min (CPU 100%) | \$/min (CPU 20%) | vs GitHub 2-core (\$0.006/min) |
+|---|---|---|---|---|
+| lite | 1/16 vCPU, 256MiB | \$0.000121 | \$0.000061 | ~1/50–1/98 |
+| basic | 1/4 vCPU, 1GiB | \$0.000467 | \$0.000227 | ~1/13–1/26 |
+| standard-1 | 1/2 vCPU, 4GiB | \$0.001234 | \$0.000754 | ~1/4.9–1/8.0 |
+| standard-3 | 2 vCPU, 8GiB | \$0.003667 | \$0.001747 | ~1/1.6–1/3.4 |
+
+GitHub's ubuntu-latest (private) is 2 vCPU / 8 GB RAM, so the spec-equivalent comparison is standard-3. Even for a build that maxes out the CPU, **Cloudflare is about 39% cheaper**, and for I/O-bound jobs running at around 20% CPU it's **about 71% cheaper**. On top of that, Cloudflare bills in 10ms increments while GitHub rounds up to the minute, so the shorter the job, the wider the gap.
+
+### Where Cloudflare Containers wins
+
+1. **Private repositories that have used up the free tier**: the overage is 39–71% cheaper at equivalent specs, and if you can drop light jobs down to basic, 1/13–1/26.
+2. **Lots of short jobs**: GitHub rounds each job up to a minute, so 1,000 ten-second jobs cost \$6.00 on GitHub vs about \$0.08 on CF basic — roughly a 75× difference.
+3. **Jobs that fit on low-spec instances** (lint, notifications, etc.).
+4. **Already paying for Workers Paid**: the included 375 vCPU-minutes/month gives you about 1,500 minutes/month of basic-equivalent jobs at no extra cost.
+
+### Where GitHub-hosted still wins
+
+1. **Public repositories**: hosted runners are free and unlimited, so there's no contest.
+2. **Usage within the free tier (2,000 min/month)**: GitHub costs \$0 while CF needs the \$5/month Workers Paid fixed cost.
+3. **Jobs that need Docker**: nested virtualization isn't available inside the Firecracker microVM, so the docker daemon won't run — container-build CI is a poor fit.
+4. **Jobs that rely on preinstalled tools**: none of the hosted runners' huge toolchain is there, so setup time becomes billed time.
+
+### Break-even point
+
+There are two ways to frame the break-even, depending on your assumptions.
+
+1. **Comparing total cost for a single account** (when GitHub Free's 2,000-minute free tier is fully available): GitHub is \$0 up to 2,000 minutes while CF starts from the \$5/month fixed cost, so the crossover is at **about 6,980 min/month for CPU-100% jobs, or about 3,830 min/month for CPU-20% jobs** (standard-3, with both platforms' free allowances included).
+2. **Comparing marginal cost** (free tier consumed by other workloads, Workers Paid already subscribed): per minute it's GitHub \$0.006 vs CF standard-3 \$0.00367 (CPU 100%) to \$0.00175 (CPU 20%), so **CF is 39–71% cheaper from the very first minute**.
+
+![Chart comparing monthly CI usage against monthly cost. GitHub Free grows at \$0.006/min beyond the 2,000-minute free tier, while Cloudflare standard-3 starts from a \$5/month fixed cost. The crossover (break-even) is around 6,980 min/month at CPU 100% and around 3,830 min/month at CPU 20%](https://cdn.sh1ma.dev/20260720_1_cloudflare_containers_github_self_hosted_runners/ci-cost-vs-usage.en.png)
+
+Looking at total cost per workload: for light usage that fits in the free tier (1,000 min/month), GitHub wins at \$0 vs CF's \$5+; at 3,000 min/month GitHub still wins (\$6.00 vs \$15.28); and at the 10,000 min/month scale CF pulls ahead (\$48.00 vs \$40.95). Jobs with lower CPU usage widen the gap further.
+
+![Bar chart comparing total monthly cost per workload. With free tiers and fixed costs included, GitHub is cheaper at 1,000 and 3,000 min/month, and Cloudflare pulls ahead at 10,000 min/month](https://cdn.sh1ma.dev/20260720_1_cloudflare_containers_github_self_hosted_runners/ci-cost-cases.en.png)
+
+## Summary
+
+- GitHub Actions self-hosted runners just work on Cloudflare Containers.
+- Webhook-driven startup + `--ephemeral` gets you "pay only while a job is running."
+- lite looks cheap but is slow, so its per-job cost is about the same as basic. basic is the practical minimum.
+- Since 2025-11, CPU is billed by actual usage, so jobs that leave CPU idle are cheaper (39–71% cheaper at equivalent specs).
+- In total-cost terms, though, GitHub's free tier and the Workers Paid \$5/month both work against CF — the crossover only comes at around 4,000–7,000 min/month. It's also a poor fit for public repositories and Docker-build-based CI.
+
+
+
+[^1]:https://x.com/sh1ma/status/2078146772367720493
+[^2]:https://x.com/sh1ma/status/2072666550436556888


### PR DESCRIPTION
## 概要

新規記事「Cloudflare Containersを使ってGitHub Self-hosted runnersを立ててみた」の日本語版・英語版を追加する。

## 変更内容

- `src/markdown/posts/20260720_1_cloudflare_containers_github_self_hosted_runners.md` (日本語版) を追加
  - webhook 駆動のエフェメラル runner 構成の解説・実装コード・実測値
  - 料金比較は 2025-11-21 の CPU 実使用量課金への改定を反映 (CPU100% / CPU20% の 2 列、損益分岐は総額比較と限界費用比較の 2 通り)
  - `$` 金額表記は remark-math の数式誤検出を避けるため `\$` にエスケープ
  - 比較グラフ 2 枚 (`cdn.sh1ma.dev/20260720_1_cloudflare_containers_github_self_hosted_runners/` 配下) を挿入
- `src/markdown/posts/en/20260720_1_cloudflare_containers_github_self_hosted_runners.md` (英語版) を追加
  - 画像は `.en.png` 版を使用

## 関連Issue

なし

## テスト項目

- [ ] `pnpm check` が通る (実行済み)
- [ ] `pnpm typecheck` が通る (実行済み)
- [ ] `/articles/20260720_1_cloudflare_containers_github_self_hosted_runners` (ja / en) が表示され、金額表記が数式化されず `$` のまま表示される
- [ ] 記事内の比較グラフ画像が表示される (CDN へのアップロードが前提)

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (記事追加のみ)

## 備考

比較グラフの画像はまだ CDN (`cdn.sh1ma.dev`) にアップロードされていないため、マージ前にアップロードが必要。元ファイルは検証リポジトリ `try-gh-self-hosted-runner-on-cf-worker` の `docs/img/` にある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSrt6s88WYGrduTVECPzMg