### PR TITLE
feat: en/ja記事をhreflangで相互に関連付ける

### DIFF
--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -558,12 +558,20 @@ const buildArticleHtml = (
   title: string,
   description: string | undefined,
   locale: "ja" | "en",
+  hasTranslation: boolean,
 ) => {
   const path = locale === "en" ? `en/articles/${slug}` : `articles/${slug}`
   const url = `${SITE_URL}/${path}`
   const ogImage = `${SITE_URL}/og/${locale === "en" ? `en/${slug}` : slug}.png`
   const desc = description ?? (locale === "en" ? "Blog article" : "ブログ記事")
+  const hreflangLinks = hasTranslation
+    ? [
+        `    <link rel="alternate" hreflang="ja" href="${SITE_URL}/articles/${slug}" />`,
+        `    <link rel="alternate" hreflang="en" href="${SITE_URL}/en/articles/${slug}" />`,
+      ]
+    : []
   const meta = [
+    ...hreflangLinks,
     `    <meta property="og:type" content="article" />`,
     `    <meta property="og:title" content="${escapeHtml(title)}" />`,
     `    <meta property="og:description" content="${escapeHtml(desc)}" />`,
@@ -604,12 +612,16 @@ for (const article of allArticles) {
       ? path.join(DIST_DIR, "en", "articles", article.id)
       : path.join(DIST_DIR, "articles", article.id)
   await mkdir(articleDir, { recursive: true })
+  const hasTranslation = allArticles.some(
+    (other) => other.id === article.id && other.locale !== article.locale,
+  )
   const html = buildArticleHtml(
     shell,
     article.id,
     article.title,
     article.description,
     locale,
+    hasTranslation,
   )
   await writeFile(path.join(articleDir, "index.html"), html)
   htmlCount++

--- a/scripts/build-sitemap.ts
+++ b/scripts/build-sitemap.ts
@@ -6,9 +6,15 @@ const SITE_URL = process.env.SITE_URL ?? "https://blog.sh1ma.dev"
 const OUT_DIR = path.resolve("./dist")
 const OUT_FILE = path.join(OUT_DIR, "sitemap.xml")
 
+type AlternateLink = {
+  hreflang: string
+  href: string
+}
+
 type UrlEntry = {
   loc: string
   lastmod?: Date
+  alternates?: AlternateLink[]
 }
 
 const XML_ESCAPE_MAP: Record<string, string> = {
@@ -30,6 +36,11 @@ const urlToXml = (entry: UrlEntry): string => {
   if (entry.lastmod) {
     children.push(`<lastmod>${entry.lastmod.toISOString()}</lastmod>`)
   }
+  for (const alternate of entry.alternates ?? []) {
+    children.push(
+      `<xhtml:link rel="alternate" hreflang="${escapeXml(alternate.hreflang)}" href="${escapeXml(alternate.href)}" />`,
+    )
+  }
   return `  <url>\n${children.map((c) => `    ${c}`).join("\n")}\n  </url>`
 }
 
@@ -37,7 +48,7 @@ const buildSitemapXml = (entries: UrlEntry[]): string => {
   const body = entries.map(urlToXml).join("\n")
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
     body,
     "</urlset>",
     "",
@@ -53,9 +64,18 @@ const staticEntries: UrlEntry[] = [
 
 const articleEntries: UrlEntry[] = allArticles.map((article) => {
   const prefix = article.locale === "en" ? "/en/articles" : "/articles"
+  const hasTranslation = allArticles.some(
+    (other) => other.id === article.id && other.locale !== article.locale,
+  )
   return {
     loc: resolveUrl(`${prefix}/${article.id}`),
     lastmod: new Date(article.publishedAt),
+    alternates: hasTranslation
+      ? [
+          { hreflang: "ja", href: resolveUrl(`/articles/${article.id}`) },
+          { hreflang: "en", href: resolveUrl(`/en/articles/${article.id}`) },
+        ]
+      : undefined,
   }
 })
 


### PR DESCRIPTION
## 概要

英訳が存在する記事について、ja 記事と en 記事を hreflang で相互に関連付けるようにした。検索エンジンが両言語版を同一コンテンツの言語違いとして認識できるようになる。

## 変更内容

- `scripts/build-ogp.ts`: 記事ごとの静的 `index.html` 生成時に、同一 id の別 locale 記事 (翻訳) が存在する場合のみ、`hreflang="ja"` / `hreflang="en"` の alternate リンク 2 本 (自己参照 + 相互参照) を `<head>` に注入するようにした。
- `scripts/build-sitemap.ts`: 翻訳が存在する記事の `<url>` エントリに `xhtml:link rel="alternate" hreflang` を併記するようにした (`urlset` に `xmlns:xhtml` 名前空間を追加)。

## 関連Issue

なし

## テスト項目

- [ ] `pnpm build` 後、`dist/articles/<slug>/index.html` と `dist/en/articles/<slug>/index.html` の両方に同一の hreflang リンク 2 本が入っている (ローカルで 46 記事すべてに注入されることを確認済み)
- [ ] `dist/sitemap.xml` の記事エントリ 46 件すべてに `xhtml:link` が 2 本ずつ (計 92 本) 入っている (ローカルで確認済み)
- [ ] 翻訳が存在しない記事には hreflang リンクが入らない
- [ ] `pnpm check` / `pnpm typecheck` が通る (確認済み)

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (UI 変更なし)

## 備考

SPA 内の遷移では `<head>` は更新されないが、クローラーが取得するのは記事ごとの静的 HTML なので SEO 上はこれで十分 (既存の OGP メタと同じ方針)。head の hreflang と sitemap の `xhtml:link` は同じペアを指しており矛盾しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GN8APvRJeJbRptVgzYzV8n