### PR TITLE
chore: Renovate の実行を日本時間の週末のみに変更し PR 数制限を撤廃

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits"],
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "schedule:weekends"
+  ],
+  "timezone": "Asia/Tokyo",
   "reviewers": ["sh1ma"],
   "labels": ["automated", "chore"],
-  "prConcurrentLimit": 10,
-  "prHourlyLimit": 3,
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 0,
   "rangeStrategy": "bump",
   "packageRules": [
     {


### PR DESCRIPTION
## 概要

Renovate が約 3.5 時間おきに随時 PR を作成する現状を見直し、PR の作成・更新を日本時間の週末のみに限定する。あわせて 1 時間あたり・同時 open 数の PR 数制限を撤廃する。

## 変更内容

- `extends` に `schedule:weekends` プリセットを追加 (cron `* * * * 0,6` = 土日のみ)
- `timezone: "Asia/Tokyo"` を追加し、スケジュール判定を日本時間にする
- `prConcurrentLimit: 10` → `0` (制限なし)
- `prHourlyLimit: 3` → `0` (制限なし)

## 関連Issue

なし

## テスト項目

- [ ] `pnpm check` が通ること (ローカルで確認済み)
- [ ] マージ後、平日に Renovate の新規 PR 作成・rebase が行われないこと
- [ ] 次の土日 (JST) に待機中の更新がまとめて PR 化されること

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし

## 備考

`schedule:weekends` の cron 展開と `prConcurrentLimit`/`prHourlyLimit` の `0 = 無制限` は Renovate 公式 docs (presets-schedule / configuration-options) で確認済み。スケジュールは PR の作成・更新 (rebase 含む) のタイミングを制御するもので、Dependency Dashboard 上の待機リスト自体は維持される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQBmN278XS6NTsRNJcZ95X