### PR TITLE
fix: 記事 URL を末尾スラッシュなしに正規化して 307 を解消

### DIFF
--- a/scripts/build-ogp.ts
+++ b/scripts/build-ogp.ts
@@ -571,6 +571,7 @@ const buildArticleHtml = (
       ]
     : []
   const meta = [
+    `    <link rel="canonical" href="${url}" />`,
     ...hreflangLinks,
     `    <meta property="og:type" content="article" />`,
     `    <meta property="og:title" content="${escapeHtml(title)}" />`,

--- a/scripts/build-sitemap.ts
+++ b/scripts/build-sitemap.ts
@@ -58,7 +58,7 @@ const buildSitemapXml = (entries: UrlEntry[]): string => {
 const staticEntries: UrlEntry[] = [
   { loc: resolveUrl("/") },
   { loc: resolveUrl("/about") },
-  { loc: resolveUrl("/en/") },
+  { loc: resolveUrl("/en") },
   { loc: resolveUrl("/en/about") },
 ]
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,7 @@
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "assets": {
     "not_found_handling": "single-page-application",
+    "html_handling": "drop-trailing-slash",
   },
   "vars": {
     "NODE_VERSION": "24.16.0",


### PR DESCRIPTION
## 概要

sitemap / hreflang が発行している **末尾スラッシュなし** の記事 URL (`/articles/xxx`) が、Cloudflare Workers Assets のデフォルト挙動 (`auto-trailing-slash`) により 307 で `/articles/xxx/` に転送されていた。外部リンクや検索エンジン経由のアクセスが常に 1 回リダイレクトを踏む状態になっていたので、これを解消する。

公開済み記事 URL (末尾スラッシュなし) は **一切変わらない**。

## 変更内容

- `wrangler.jsonc`: `assets.html_handling` を `drop-trailing-slash` に設定。既存の `articles/xxx/index.html` 出力構造そのままで末尾スラッシュなし側が canonical 200 として配信され、slash 付き URL は 307 で保持される。
- `scripts/build-ogp.ts`: 記事 HTML に `<link rel="canonical" href="...">` を追加。
- `scripts/build-sitemap.ts`: `/en/` を `/en` に修正 (redirect 対象を canonical に揃える)。

## 関連Issue

なし (Google Analytics で `/articles/xxx` no-slash と `/articles/xxx/` slash が両方 PV 計上されているのを見つけて調査した結果)。

## テスト項目

ローカルで `pnpm build && pnpm wrangler dev` を起動し、以下を curl で確認済み:

- [x] `/articles/20260706_cloudflare_agentic_inbox` → 200
- [x] `/articles/20260706_cloudflare_agentic_inbox/` → 307 → no-slash
- [x] `/en/articles/20260706_cloudflare_agentic_inbox` → 200
- [x] `/en/articles/20260706_cloudflare_agentic_inbox/` → 307 → no-slash
- [x] `/en` → 200 / `/en/` → 307
- [x] `/` → 200
- [x] 記事 HTML に `<link rel="canonical">` と `hreflang` が期待どおり出力
- [x] `pnpm check` / `pnpm typecheck` を通過

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

UI 変更なし。

## スクリーンショット（任意）

なし。

## 備考

- `/about` (ja) と `/feed` は SPA フォールバック経由なので `html_handling` が効かず、末尾スラッシュ有無で両方 200 のまま。本 PR のスコープ (記事 URL の canonical 化) 外なので手を入れていない。必要になれば別 PR で。
- 既存の hreflang / sitemap で使ってきた no-slash URL がそのまま canonical になるので、外部リンク・被リンク評価の付替えは不要。