### PR TITLE
fix: pnpm の設定を pnpm-workspace.yaml に移して Renovate の lockfile 更新を修復

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,18 +83,5 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css}": "biome check --write --no-errors-on-unmatched"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.2.17",
-      "@types/react-dom": "19.2.3",
-      "js-yaml@<3.15.0": "^3.15.0"
-    },
-    "onlyBuiltDependencies": [
-      "protobufjs",
-      "workerd",
-      "esbuild",
-      "@biomejs/biome"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+overrides:
+  "@types/react": 19.2.17
+  "@types/react-dom": 19.2.3
+  js-yaml@<3.15.0: ^3.15.0
+
+onlyBuiltDependencies:
+  - protobufjs
+  - workerd
+  - esbuild
+  - "@biomejs/biome"


### PR DESCRIPTION
## 概要

Renovate が生成する `pnpm-lock.yaml` から `overrides` が丸ごと欠落し、ほぼ全ての Renovate PR が CI で落ちていた問題を根本から修正する。

原因は Renovate が **pnpm 11** で lockfile を更新している一方、pnpm 11 では `package.json` の `pnpm` フィールドが読まれなくなったこと。Renovate 側のログにも以下が出ていた。

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
The following keys were ignored: "pnpm.overrides", "pnpm.onlyBuiltDependencies".
```

その結果 `overrides` を含まない lockfile が生成され、pnpm 10.34.5 を使う CI 側で `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` / `ERR_PNPM_OUTDATED_LOCKFILE` が発生していた。

## 変更内容

- `pnpm-workspace.yaml` を新規追加し、`overrides` と `onlyBuiltDependencies` を移設
- `package.json` から `pnpm` フィールドを削除

`pnpm-workspace.yaml` は pnpm 10 / 11 の両方から読まれるため、Renovate 側 (pnpm 11) でも overrides が反映された lockfile が生成されるようになる。

## 関連Issue

なし

## テスト項目

- [x] `pnpm install` 後の `pnpm-lock.yaml` が変更前と完全に一致する (overrides が保持されている)
- [x] `pnpm install --frozen-lockfile` が成功する
- [x] `pnpm check` が通る
- [x] `pnpm typecheck` が通る
- [x] `onlyBuiltDependencies` が引き続き効いている (ビルド許可外は `Ignored build scripts` として警告される)

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (UI 変更なし)

## 備考

- 依存の実バージョンは一切変わらず、`pnpm-lock.yaml` にも差分が出ない設定ファイルの移設のみ。
- `onlyBuiltDependencies` は pnpm 11 で `allowBuilds` にリネームされている。pnpm 本体を 11 に上げる際 (#248) に合わせて改名が必要。