### PR TITLE
chore(renovate): js-yaml を 3.x に固定する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,11 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "labels": ["automated", "chore", "major-update"]
+    },
+    {
+      "description": "js-yaml は 4.0.0 で safeLoad が削除され、gray-matter@4 (記事の frontmatter 解析に使用) が動かなくなるため 3.x に固定する。脆弱性は 3.15.0 で修正済みで、pnpm overrides もその下限を保証している",
+      "matchPackageNames": ["js-yaml"],
+      "allowedVersions": "<4"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
## 概要

Renovate PR #246 (`js-yaml@<3.15.0` の pnpm overrides を `^3.15.0` → `^5.2.2` に上げる) は、適用すると**記事のビルドが完全に壊れる**ことを確認した。Renovate が今後同じ更新を提案しないよう、js-yaml を 3.x に固定する。

### 壊れる理由

js-yaml 4.0.0 で `safeLoad` / `safeDump` が削除された ([CHANGELOG](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md))。記事の frontmatter 解析に使われている `gray-matter@4.0.3` は以下のように `safeLoad` を直接参照しているため、js-yaml 4 以降では読み込み時点で落ちる。

`#246` のブランチで実際に `pnpm build:content` を実行した結果:

```
node_modules/.pnpm/gray-matter@4.0.3/node_modules/gray-matter/lib/engines.js:16
  parse: yaml.safeLoad.bind(yaml),
                       ^
TypeError: Cannot read properties of undefined (reading 'bind')
```

### 上げる必要がない理由

この overrides はもともと GHSA 対応 (commit 3acc316) で入れたもので、**脆弱性は js-yaml 3.15.0 で修正済み**。既存の `js-yaml@<3.15.0: ^3.15.0` がその下限を保証しているため、4.x 以降に上げる必要はない。

## 変更内容

- `renovate.json` の `packageRules` に js-yaml の `allowedVersions: "<4"` を追加

## 関連Issue

なし (PR #246 はこの PR のマージ後にクローズする)

## テスト項目

- [x] `renovate.json` が valid な JSON であること
- [x] `pnpm install --frozen-lockfile` が通ること
- [x] `pnpm check` が通ること
- [x] #246 のブランチで `pnpm build:content` が TypeError で失敗することを確認 (この PR が必要な根拠)

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

## スクリーンショット（任意）

なし (UI 変更なし)

## 備考

Renovate 設定のみの変更で、依存の実バージョンや `pnpm-lock.yaml` には差分が出ない。