### PR TITLE
fix: deprecated な API 利用を解消し lint で検出できるようにする

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -42,6 +42,7 @@
         "useSelfClosingElements": "off"
       },
       "suspicious": {
+        "noDeprecatedImports": "error",
         "noExplicitAny": "warn",
         "noAssignInExpressions": "off",
         "noImplicitAnyLet": "off"

--- a/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/src/components/MarkdownContent/MarkdownContent.tsx
@@ -35,7 +35,6 @@ function loadTwitterWidgets(container: HTMLElement) {
   const script = document.createElement("script")
   script.src = TWITTER_WIDGET_SRC
   script.async = true
-  script.charset = "utf-8"
   script.addEventListener("load", hydrate, { once: true })
   document.body.appendChild(script)
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,14 @@
 import path from "node:path"
 import { cloudflare } from "@cloudflare/vite-plugin"
 import contentCollections from "@content-collections/vite"
-import { TanStackRouterVite } from "@tanstack/router-plugin/vite"
+import { tanstackRouter } from "@tanstack/router-plugin/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
 export default defineConfig({
   plugins: [
     contentCollections(),
-    TanStackRouterVite({
+    tanstackRouter({
       target: "react",
       autoCodeSplitting: true,
       routesDirectory: "./src/routes",


### PR DESCRIPTION
## 概要

コードベースに残っていた deprecated な API 利用を解消し、あわせて「deprecated な import」を lint で検出できるようにした。

調査には TypeScript Language Service の `getSuggestionDiagnostics()` を使い、`reportsDeprecated` フラグの立った診断を `src/` `lib/` `scripts/` `e2e/` と各 config ファイルに対して全走査した。ヒットは 3 件 (2 ファイル) で、いずれも本 PR で解消している。

### lint で弾けていたか

**弾けていなかった。** 内訳は以下の通り。

| 種別 | 検出可否 | 理由 |
| --- | --- | --- |
| deprecated な **import** (`TanStackRouterVite`) | 素通り | Biome に `suspicious/noDeprecatedImports` は存在するが recommended に含まれず既定で無効。`biome.json` にも未記載だった |
| deprecated な **プロパティ/メソッド** (`script.charset`) | 検出不可 | Biome に該当ルールが存在しない。TypeScript の suggestion diagnostics でしか出ない診断で、`tsc` の CLI にも出ない |

前者は本 PR でルールを有効化して塞いだ。後者は Biome 側に手段がないため、今回は lint 化を見送っている (「備考」参照)。

## 変更内容

- `vite.config.ts`: `TanStackRouterVite` → `tanstackRouter` に置換
  - `@tanstack/router-plugin` の `dist/esm/vite.js:48` が `var TanStackRouterVite = tanstackRouter` という完全なエイリアスで、JSDoc も `@deprecated Use tanstackRouter instead.` と明示している。挙動差はない
- `src/components/MarkdownContent/MarkdownContent.tsx`: `script.charset = "utf-8"` を削除
  - `lib.dom.d.ts` で `HTMLScriptElement.charset` は `@deprecated`
  - MDN も *"It's unnecessary to specify the charset attribute, because documents must use UTF-8, and the script element inherits its character encoding from the document"* と記載
  - `index.html:4` が `<meta charset="UTF-8" />` なので、Twitter ウィジェットの読み込み挙動は変わらない
- `biome.json`: `linter.rules.suspicious.noDeprecatedImports` を `"error"` で追加
  - 有効化した状態で実際に `vite.config.ts:4` を検出できることを確認済み (node_modules の `.d.ts` の JSDoc も読める)
  - 以後 deprecated な import は `pnpm check` で落ちる

## 関連Issue

なし

## テスト項目

- [x] 再スキャンで deprecated 使用箇所が 0 件になること
- [x] `pnpm check` が exit 0 (warning 5 / info 1 は変更前と同一の既存分)
- [x] `pnpm typecheck` が exit 0
- [x] `pnpm build` が成功すること (`tanstackRouter` へ置換後もルート生成・OGP 48 枚・sitemap 52 URL まで通過)
- [ ] CI の E2E / VRT が通ること

## VRT設定

<!-- UIに意図的な変更がある場合のみチェックしてください -->

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

UI に意図的な変更はないため、スナップショット更新は不要。

## スクリーンショット（任意）

なし (見た目の変更なし)

## 備考

- `script.charset` のような「deprecated なプロパティ/メソッド利用」は Biome では検出できないため、今回は検出の仕組みを恒久化していない。調査に使ったスクリプトは使い捨てとし、リポジトリには追加していない。必要になったら TS Language Service ベースの検出スクリプトを `scripts/` に置いて CI に組み込む余地はある。
- `noDeprecatedImports` は `project` ドメインのルール (Biome 2.2.5 以降)。既定 severity は `warn` だが、CI で確実に止めたいので `error` を指定している。
