### PR TITLE
chore(deps): update dependency typescript to v7

### DIFF
--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -32,12 +32,14 @@ test.describe("トップページ", () => {
     )
     await expect(metaInfo).toBeVisible()
 
+    // react-icons はアイコン名を class に出さないため、項目の中身で特定する
+
     // カレンダーアイコン（日付）が表示される
-    const calendarIcon = metaInfo.locator('svg[class*="lucide-calendar"]')
+    const calendarIcon = metaInfo.locator("span:has(time) svg")
     await expect(calendarIcon).toBeVisible()
 
     // 時計アイコン（読了時間）が表示される
-    const clockIcon = metaInfo.locator('svg[class*="lucide-clock"]')
+    const clockIcon = metaInfo.locator("span:has(time) ~ span svg")
     await expect(clockIcon).toBeVisible()
 
     // 2つのメタ情報が同じ行に表示されていることを確認

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "remark-math": "^6.0.0",
     "remark-rehype": "^11.1.2",
     "shiki": "^4.4.2",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 7.0.2
+        version: 7.0.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.7
@@ -82,16 +82,16 @@ importers:
         version: 1.51.1(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))(wrangler@4.120.0)
       '@content-collections/cli':
         specifier: ^0.1.9
-        version: 0.1.9(@content-collections/core@0.15.2(typescript@5.9.3))
+        version: 0.1.9(@content-collections/core@0.15.2(typescript@7.0.2))
       '@content-collections/core':
         specifier: ^0.15.2
-        version: 0.15.2(typescript@5.9.3)
+        version: 0.15.2(typescript@7.0.2)
       '@content-collections/markdown':
         specifier: ^0.1.4
-        version: 0.1.4(@content-collections/core@0.15.2(typescript@5.9.3))(supports-color@10.2.2)
+        version: 0.1.4(@content-collections/core@0.15.2(typescript@7.0.2))(supports-color@10.2.2)
       '@content-collections/vite':
         specifier: ^0.3.0
-        version: 0.3.0(@content-collections/core@0.15.2(typescript@5.9.3))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
+        version: 0.3.0(@content-collections/core@0.15.2(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
@@ -1491,6 +1491,126 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
@@ -2448,9 +2568,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@7.18.2:
@@ -2873,16 +2993,16 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260801.1':
     optional: true
 
-  '@content-collections/cli@0.1.9(@content-collections/core@0.15.2(typescript@5.9.3))':
+  '@content-collections/cli@0.1.9(@content-collections/core@0.15.2(typescript@7.0.2))':
     dependencies:
       '@clerc/core': 1.3.1
       '@clerc/plugin-completions': 1.3.1(@clerc/core@1.3.1)
       '@clerc/plugin-help': 1.3.1(@clerc/core@1.3.1)
       '@clerc/plugin-version': 1.3.1(@clerc/core@1.3.1)
-      '@content-collections/core': 0.15.2(typescript@5.9.3)
-      '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.2(typescript@5.9.3))
+      '@content-collections/core': 0.15.2(typescript@7.0.2)
+      '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.2(typescript@7.0.2))
 
-  '@content-collections/core@0.15.2(typescript@5.9.3)':
+  '@content-collections/core@0.15.2(typescript@7.0.2)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       camelcase: 8.0.0
@@ -2894,16 +3014,16 @@ snapshots:
       pluralize: 8.0.0
       serialize-javascript: 7.0.7
       tinyglobby: 0.2.17
-      typescript: 5.9.3
+      typescript: 7.0.2
       yaml: 2.9.0
 
-  '@content-collections/integrations@0.5.0(@content-collections/core@0.15.2(typescript@5.9.3))':
+  '@content-collections/integrations@0.5.0(@content-collections/core@0.15.2(typescript@7.0.2))':
     dependencies:
-      '@content-collections/core': 0.15.2(typescript@5.9.3)
+      '@content-collections/core': 0.15.2(typescript@7.0.2)
 
-  '@content-collections/markdown@0.1.4(@content-collections/core@0.15.2(typescript@5.9.3))(supports-color@10.2.2)':
+  '@content-collections/markdown@0.1.4(@content-collections/core@0.15.2(typescript@7.0.2))(supports-color@10.2.2)':
     dependencies:
-      '@content-collections/core': 0.15.2(typescript@5.9.3)
+      '@content-collections/core': 0.15.2(typescript@7.0.2)
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
       remark-parse: 11.0.0(supports-color@10.2.2)
@@ -2912,10 +3032,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@content-collections/vite@0.3.0(@content-collections/core@0.15.2(typescript@5.9.3))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))':
+  '@content-collections/vite@0.3.0(@content-collections/core@0.15.2(typescript@7.0.2))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))':
     dependencies:
-      '@content-collections/core': 0.15.2(typescript@5.9.3)
-      '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.2(typescript@5.9.3))
+      '@content-collections/core': 0.15.2(typescript@7.0.2)
+      '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.2(typescript@7.0.2))
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0)
 
   '@cspotcode/source-map-support@0.8.1':
@@ -3679,6 +3799,66 @@ snapshots:
       csstype: 3.2.3
 
   '@types/unist@3.0.3': {}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@ungap/structured-clone@1.3.3': {}
 
@@ -4913,7 +5093,28 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  typescript@5.9.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@7.18.2: {}
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "baseUrl": ".",
+    "types": ["vite/client", "node"],
     "paths": {
       "@/*": ["./src/*"],
       "content-collections": ["./.content-collections/generated"],

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -14,6 +14,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
+    "types": ["node"],
   },
   "include": ["vite.config.ts", "content-collections.ts", "lib/**/*.ts"],
 }


### PR DESCRIPTION
## 概要

TypeScript を 5.9.3 から 7.0.2 (最新安定版) へ更新する。TypeScript 6.0 で入った 3 つの破壊的変更に引っかかるため、あわせて `tsconfig` を修正した。

Renovate の #253 は `package.json` / `pnpm-lock.yaml` しか更新しておらず、そのままでは `pnpm typecheck` と `pnpm build` が両方 CI で落ちる。本 PR で置き換えるため #253 は close 済み。

あわせて、手元で E2E を流した際に見つかった既存の失敗 (本 PR とは無関係、main 時点で壊れている) も直している。詳細は後述。

## 変更内容

### TypeScript v7 対応

- `typescript` を `5.9.3` → `7.0.2` に更新 (`pnpm add -E` で追加、既存の固定バージョン指定を踏襲)
- `tsconfig.app.json`: `baseUrl` を削除
  - TS6.0 で `baseUrl` が削除され、残っていると `error TS5102` で config 自体が弾かれる
  - `paths` はもともと `./src/*` のように tsconfig からの相対パスで書かれているため、削除以外の対応は不要 (TS 5.9.3 のまま `baseUrl` だけ消しても typecheck が通ることを確認済み)
- `tsconfig.node.json` / `tsconfig.app.json`: `types` を明示追加
  - TS6.0 で `types` のデフォルトが `[]` になり、`node_modules/@types` の自動読み込みが廃止された。そのため `node:fs` / `node:path` / `process` が `error TS2591` で解決できなくなる
  - `tsconfig.node.json` に `"node"` を追加
  - `tsconfig.app.json` にも `"node"` が必要。`.content-collections/generated/index.d.ts` が `import configuration from "../../content-collections.ts"` しており、app プロジェクト側にも `content-collections.ts` → `lib/ogp-fetcher.ts` という node 依存のコードが引き込まれるため
- `tsconfig.app.json`: `types` に `vite/client` を追加
  - TS6.0 で `noUncheckedSideEffectImports` がデフォルト `true` になり、`src/main.tsx` の `import "./globals.css"` が `error TS2882` になる
  - `vite/client` が `declare module '*.css' {}` を持っているのでこれで解決する。`noUncheckedSideEffectImports: false` でチェック自体を切る対応は取っていない

### E2E の既存の失敗を修正 (本 PR の変更とは無関係)

- `e2e/index.spec.ts` の「記事カードのメタ情報が横並びで表示される」が常に失敗していたので直した
  - lucide-react から react-icons へ移行した 19e1a7b (2026-07-31 に main へマージ済み) 以降、react-icons はアイコン名を `class` に出力しない (`react-icons/lib/iconBase.mjs` は `props.className` を渡さない限り `class` 属性自体を出さない) ため、`svg[class*="lucide-calendar"]` がどの要素にもマッチしていなかった
  - 19e1a7b は `e2e/` を一切変更しておらず、かつ E2E ワークフローが無効化されているため CI で検知されていなかった
  - アイコン名で特定する代わりに、メタ情報の項目の中身で特定するようにした。日付側は `time` 要素を含む項目 (`span:has(time) svg`)、読了時間側はその後続で svg を持つ項目 (`span:has(time) ~ span svg`) として一意に決まる
  - 横並びを検証する boundingBox の比較はそのまま維持している

## 関連Issue

Renovate PR #253 を置き換える。

## テスト項目

- [x] `pnpm typecheck` が通る
- [x] `pnpm build` が通る (vite build / feed / sitemap / OGP 生成まで完走)
- [x] `pnpm check` (biome) が通る
- [x] `pnpm test:e2e` が通る (39 passed / 0 failed。修正前は 38 passed / 1 failed)

## VRT設定

- [ ] スナップショットを更新する（UI変更を意図的に行った場合にチェック）

UI の変更はない。`tsc` は `noEmit` で型チェックにしか使っておらず、バンドル生成は Vite 側が行うため成果物は変わらない想定。

## スクリーンショット（任意）

なし。

## 備考

- TypeScript 7 系の最新は 7.0.2 (`pnpm view typescript dist-tags` で確認)。Renovate が提案していたバージョンと同じ。
- `pnpm why typescript` で確認したところ typescript は単一バージョンに解決されており、`@content-collections/*` からの peer 警告も出ていない。
- `tsconfig.app.json` に `"node"` を入れるのは理想的ではないが、TS 5.9.3 までは `@types` 自動読み込みによって同じ型が入っていたため、実質的な型の見え方は従来どおり。generated な `.d.ts` がルートの `content-collections.ts` を参照する構造が変わらない限り避けられない。
- **E2E Tests / Visual Regression Tests のワークフローが `disabled_manually` で無効化されている** (最後の実行は 2026-07-05)。そのため本 PR の E2E は CI では走らず、手元の `pnpm test:e2e` で確認している。無効化が意図的かどうか判断できなかったため、ワークフローの再有効化は本 PR では行っていない。